### PR TITLE
Feature/sim 2096/phosim interface

### DIFF
--- a/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
@@ -16,10 +16,19 @@ class CompoundInstanceCatalog(object):
     ASCII file using the same API as InstanceCatalog.write_catalog.
 
     Note: any member variables of the CompoundInstanceCatalog whose names
-    do not begin with '_' will be assigned to the InstanceCatalog created
-    by the CompoundInstanceCatalog.  This allows you to, for example, format
-    the outputs of every InstanceCatalog in the CompoundInstanceCatalog by
-    setting override_formats in just the CompoundInstanceCatalog.
+    do not begin with '_' will be assigned to the InstanceCatalogs iterated
+    over by the CompoundInstanceCatalog.  This allows you to, for example,
+    format the outputs of every InstanceCatalog in the CompoundInstanceCatalog
+    by setting override_formats in just the CompoundInstanceCatalog, e.g.
+
+    class myCompoundInstanceCatalog(CompoundInstanceCatalog):
+        transformations = {'raJ2000': np.degrees, 'decJ2000': np.degrees}
+
+    comCat = myCompoundInstanceCatalog([catClass1, catClass2],
+                                       [dbClass1, dbClass2])
+
+    will write raJ2000 and decJ2000 in degrees without having to define
+    transformations in catClass1 and catClass2.
     """
 
     def __init__(self, instanceCatalogClassList, catalogDBObjectClassList,

--- a/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
@@ -15,6 +15,12 @@ class CompoundInstanceCatalog(object):
 
     The write_catalog method then writes all of the InstanceCatalogs to one
     ASCII file using the same API as InstanceCatalog.write_catalog.
+
+    Note: any member variables of the CompoundInstanceCatalog whose names
+    do not begin with '_' will be assigned to the InstanceCatalog created
+    by the CompoundInstanceCatalog.  This allows you to, for example, format
+    the outputs of every InstanceCatalog in the CompoundInstanceCatalog by
+    setting override_formats in just the CompoundInstanceCatalog.
     """
 
     def __init__(self, instanceCatalogClassList, catalogDBObjectClassList,
@@ -211,6 +217,17 @@ class CompoundInstanceCatalog(object):
                 dbo = dboClass(connection=best_connection)
 
             ic = icClass(dbo, obs_metadata=self._obs_metadata)
+
+            # assign all non-private member variables of the CompoundInstanceCatalog
+            # to the instantiated InstanceCatalogs
+            for kk in self.__dict__:
+                if kk[0] != '_' and not hasattr(self.__dict__[kk], '__call__'):
+                    setattr(ic, kk, self.__dict__[kk])
+
+            for kk in self.__class__.__dict__:
+                if kk[0] != '_' and not hasattr(self.__class__.__dict__[kk], '__call__'):
+                    setattr(ic, kk, self.__class__.__dict__[kk])
+
             ic._write_pre_process()
             instantiated_ic_list[ix] = ic
 

--- a/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
@@ -1,6 +1,5 @@
 from __future__ import with_statement
 import numpy
-from collections import OrderedDict
 from lsst.sims.catalogs.db import CompoundCatalogDBObject
 
 
@@ -79,7 +78,6 @@ class CompoundInstanceCatalog(object):
 
                 self._dbObjectGroupList.append(new_row)
 
-
     def areDBObjectsTheSame(self, db1, db2):
         """
         @param [in] db1 is a CatalogDBObject instantiation
@@ -120,7 +118,6 @@ class CompoundInstanceCatalog(object):
         else:
             driver2 = None
 
-
         if db1.tableid != db2.tableid:
             return False
         if host1 != host2:
@@ -132,7 +129,6 @@ class CompoundInstanceCatalog(object):
         if driver1 != driver2:
             return False
         return True
-
 
     def find_a_connection(self, dboClass):
         """
@@ -164,12 +160,10 @@ class CompoundInstanceCatalog(object):
         else:
             desired_port = None
 
-
         if hasattr(dboClass, 'verbose'):
             desired_verbose = dboClass.verbose
         else:
             desired_verbose = False
-
 
         best_connection = None
 
@@ -184,7 +178,6 @@ class CompoundInstanceCatalog(object):
                 break
 
         return best_connection
-
 
     def write_catalog(self, filename, chunk_size=None, write_header=True, write_mode='w'):
         """
@@ -231,9 +224,8 @@ class CompoundInstanceCatalog(object):
             ic._write_pre_process()
             instantiated_ic_list[ix] = ic
 
-
         for row in self._dbObjectGroupList:
-            if len(row)==1:
+            if len(row) == 1:
                 ic = instantiated_ic_list[row[0]]
                 ic._query_and_write(filename, chunk_size=chunk_size,
                                     write_header=write_header, write_mode=write_mode,
@@ -256,7 +248,7 @@ class CompoundInstanceCatalog(object):
                     default_compound_dbo is CompoundCatalogDBObject
 
         for row in self._dbObjectGroupList:
-            if len(row)>1:
+            if len(row) > 1:
                 dbObjClassList = [self._dbo_list[ix] for ix in row]
                 catList = [instantiated_ic_list[ix] for ix in row]
 
@@ -276,8 +268,8 @@ class CompoundInstanceCatalog(object):
                     compound_dbo = None
                     for candidate in self._compoundDBclass:
                         use_it = True
-                        if False in [candidate._table_restriction is not None \
-                                     and dbo.tableid in candidate._table_restriction \
+                        if False in [candidate._table_restriction is not None and
+                                     dbo.tableid in candidate._table_restriction
                                      for dbo in dbObjClassList]:
 
                             use_it = False
@@ -289,13 +281,11 @@ class CompoundInstanceCatalog(object):
                     if compound_dbo is None:
                         compound_dbo = default_compound_dbo(dbObjClassList)
 
-
                 self._write_compound(catList, compound_dbo, filename,
                                      chunk_size=chunk_size, write_header=write_header,
                                      write_mode=write_mode)
                 write_mode = 'a'
                 write_header = False
-
 
     def _write_compound(self, catList, compound_dbo, filename,
                         chunk_size=None, write_header=False, write_mode='a'):
@@ -336,7 +326,6 @@ class CompoundInstanceCatalog(object):
             master_colnames.append(localNames)
             name_map.append(local_map)
 
-
         master_results = compound_dbo.query_columns(colnames=colnames,
                                                     obs_metadata=self._obs_metadata,
                                                     constraint=self._constraint,
@@ -345,7 +334,6 @@ class CompoundInstanceCatalog(object):
         with open(filename, write_mode) as file_handle:
             if write_header:
                 catList[0].write_header(file_handle)
-
 
             new_dtype_list = [None]*len(catList)
 
@@ -360,14 +348,13 @@ class CompoundInstanceCatalog(object):
 
                     local_recarray = chunk[master_colnames[ix]].view(numpy.recarray)
 
-                    local_recarray.flags['WRITEABLE'] = False # so numpy does not raise a warning
-                                                              # because it thinks we may accidentally
-                                                              # write to this array
+                    local_recarray.flags['WRITEABLE'] = False  # so numpy does not raise a warning
+                                                               # because it thinks we may accidentally
+                                                               # write to this array
                     if new_dtype_list[ix] is None:
-                        new_dtype = numpy.dtype([
-                                                tuple([dd.replace(catName+'_','')] + [local_recarray.dtype[dd]]) \
-                                                for dd in master_colnames[ix]
-                                                ])
+                        new_dtype = numpy.dtype([tuple([dd.replace(catName+'_', '')] +
+                                                       [local_recarray.dtype[dd]])
+                                                for dd in master_colnames[ix]])
                         new_dtype_list[ix] = new_dtype
 
                     local_recarray.dtype = new_dtype_list[ix]

--- a/python/lsst/sims/catalogs/utils/testUtils.py
+++ b/python/lsst/sims/catalogs/utils/testUtils.py
@@ -1,8 +1,6 @@
 import os
 import sqlite3
-from numpy.random import random
-from numpy.random import seed
-import numpy
+import numpy as np
 import json
 
 from lsst.sims.utils import ObservationMetaData
@@ -35,33 +33,40 @@ def writeResult(result, fname):
     fh.close()
 
 
-def sampleSphere(size, ramin = 0., dra = 2.*numpy.pi):
+def sampleSphere(size, ramin = 0., dra = 2.*np.pi, rng=None):
     # From Shao 1996: "Spherical Sampling by Archimedes' Theorem"
-    ra = random(size)*dra
+    if rng is None:
+        rng = np.random.RandomState(42)
+
+    ra = rng.random_sample(size)*dra
     ra += ramin
-    ra %= 2*numpy.pi
-    z = random(size)*2. - 1.
-    dec = numpy.arccos(z) - numpy.pi/2.
+    ra %= 2*np.pi
+    z = rng.random_sample(size)*2. - 1.
+    dec = np.arccos(z) - np.pi/2.
     return ra, dec
 
 
-def sampleFocus(size, raCenter, decCenter, radius):
+def sampleFocus(size, raCenter, decCenter, radius, rng=None):
     """
     Sample points in a focused field of view
     @param [in] raCenter is the RA at the center of the field of view in radians
     @param [in] decCenter is the Dec at the center of the field of view in radians
     @param [in] radius is the radius of the field of view in radians
+    @param [in] rng is a random number generator (an instance of np.random.RandomState)
     @param [out] returns numpy arrays of ra and decs in radians
     """
-    theta = numpy.random.sample(size)
-    rc = numpy.radians(raCenter)
-    dc = numpy.radians(decCenter)
-    rr = numpy.radians(radius)*numpy.random.sample(size)
-    ra = numpy.empty(size)
-    dec = numpy.empty(size)
+    if rng is None:
+        rng = np.random.RandomState(1453)
+
+    theta = rng.random_sample(size)
+    rc = np.radians(raCenter)
+    dc = np.radians(decCenter)
+    rr = np.radians(radius)*rng.random_sample(size)
+    ra = np.empty(size)
+    dec = np.empty(size)
     for i, th in enumerate(theta):
-        ra[i] = rc + rr*numpy.cos(th)
-        dec[i] = dc + rr*numpy.sin(th)
+        ra[i] = rc + rr*np.cos(th)
+        dec[i] = dc + rr*np.sin(th)
 
     return ra, dec
 
@@ -79,8 +84,8 @@ class myTestGals(CatalogDBObject):
     decColName = 'decl'
     spatialModel = 'SERSIC2D'
     columns = [('id', None, int),
-               ('raJ2000', 'ra*%f'%(numpy.pi/180.)),
-               ('decJ2000', 'decl*%f'%(numpy.pi/180.)),
+               ('raJ2000', 'ra*%f'%(np.pi/180.)),
+               ('decJ2000', 'decl*%f'%(np.pi/180.)),
                ('umag', None),
                ('gmag', None),
                ('rmag', None),
@@ -121,37 +126,41 @@ def makeGalTestDB(filename='testDatabase.db', size=1000, seedVal=None,
         conn.commit()
     except:
         raise RuntimeError("Error creating database.")
-    if seedVal:
-        seed(seedVal)
+
+    if seedVal is not None:
+        rng = np.random.RandomState(seedVal)
+    else:
+        rng = np.random.RandomState(3321)
 
     if raCenter is None or decCenter is None or radius is None:
-        ra, dec = sampleSphere(size, **kwargs)
+
+        ra, dec = sampleSphere(size, rng=rng, **kwargs)
     else:
-        rc = numpy.radians(raCenter)
-        dc = numpy.radians(decCenter)
-        ra, dec = sampleFocus(size, rc, dc, radius)
+        rc = np.radians(raCenter)
+        dc = np.radians(decCenter)
+        ra, dec = sampleFocus(size, rc, dc, radius, rng=rng)
     # Typical colors for main sequece stars
     umg = 1.5
     gmr = 0.65
     rmi = 1.0
     imz = 0.45
     zmy = 0.3
-    mag_norm_disk = random(size)*6. + 18.
-    mag_norm_bulge = random(size)*6. + 18.
-    mag_norm_agn = random(size)*6. + 19.
-    redshift = random(size)*2.5
+    mag_norm_disk = rng.random_sample(size)*6. + 18.
+    mag_norm_bulge = rng.random_sample(size)*6. + 18.
+    mag_norm_agn = rng.random_sample(size)*6. + 19.
+    redshift = rng.random_sample(size)*2.5
 
-    a_disk = random(size)*2.
-    flatness = random(size)*0.8  # To prevent linear galaxies
+    a_disk = rng.random_sample(size)*2.
+    flatness = rng.random_sample(size)*0.8  # To prevent linear galaxies
     b_disk = a_disk*(1 - flatness)
 
-    a_bulge = random(size)*1.5
-    flatness = random(size)*0.5
+    a_bulge = rng.random_sample(size)*1.5
+    flatness = rng.random_sample(size)*0.5
     b_bulge = a_bulge*(1 - flatness)
 
     # assume mag norm is g-band (which is close to true)
-    mag_norm = -2.5*numpy.log10(numpy.power(10, mag_norm_disk/-2.5) + numpy.power(10, mag_norm_bulge/-2.5) +
-                                numpy.power(10, mag_norm_agn/-2.5))
+    mag_norm = -2.5*np.log10(np.power(10, mag_norm_disk/-2.5) + np.power(10, mag_norm_bulge/-2.5) +
+                             np.power(10, mag_norm_agn/-2.5))
     umag = mag_norm + umg
     gmag = mag_norm
     rmag = gmag - gmr
@@ -159,14 +168,14 @@ def makeGalTestDB(filename='testDatabase.db', size=1000, seedVal=None,
     zmag = imag - imz
     ymag = zmag - zmy
     for i in xrange(size):
-        period = random()*490. + 10.
-        amp = random()*5. + 0.2
+        period = rng.random_sample(1)[0]*490. + 10.
+        amp = rng.random_sample(1)[0]*5. + 0.2
         varParam = {'varMethodName': 'testVar', 'pars': {'period': period, 'amplitude': amp}}
         paramStr = json.dumps(varParam)
         qstr = '''INSERT INTO galaxies VALUES (%i, %f, %f, %f,
                      %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f,
                      %f, %f, '%s')''' % \
-               (i, numpy.degrees(ra[i]), numpy.degrees(dec[i]), umag[i], gmag[i], rmag[i], imag[i],
+               (i, np.degrees(ra[i]), np.degrees(dec[i]), umag[i], gmag[i], rmag[i], imag[i],
                 zmag[i], ymag[i], mag_norm_agn[i], mag_norm_bulge[i], mag_norm_disk[i], redshift[i],
                 a_disk[i], b_disk[i], a_bulge[i], b_bulge[i], paramStr)
 
@@ -190,11 +199,11 @@ class myTestStars(CatalogDBObject):
     raColName = 'ra'
     decColName = 'decl'
     columns = [('id', None, int),
-               ('raJ2000', 'ra*%f'%(numpy.pi/180.)),
-               ('decJ2000', 'decl*%f'%(numpy.pi/180.)),
-               ('parallax', 'parallax*%.15f'%(numpy.pi/(648000000.0))),
-               ('properMotionRa', 'properMotionRa*%.15f'%(numpy.pi/180)),
-               ('properMotionDec', 'properMotionDec*%.15f'%(numpy.pi/180.)),
+               ('raJ2000', 'ra*%f'%(np.pi/180.)),
+               ('decJ2000', 'decl*%f'%(np.pi/180.)),
+               ('parallax', 'parallax*%.15f'%(np.pi/(648000000.0))),
+               ('properMotionRa', 'properMotionRa*%.15f'%(np.pi/180)),
+               ('properMotionDec', 'properMotionDec*%.15f'%(np.pi/180.)),
                ('umag', None),
                ('gmag', None),
                ('rmag', None),
@@ -228,15 +237,18 @@ def makeStarTestDB(filename='testDatabase.db', size=1000, seedVal=None,
         conn.commit()
     except:
         raise RuntimeError("Error creating database.")
-    if seedVal:
-        seed(seedVal)
+
+    if seedVal is not None:
+        rng = np.random.RandomState(seedVal)
+    else:
+        rng = np.random.RandomState(88)
 
     if raCenter is None or decCenter is None or radius is None:
-        ra, dec = sampleSphere(size, **kwargs)
+        ra, dec = sampleSphere(size, rng=rng, **kwargs)
     else:
-        rc = numpy.radians(raCenter)
-        dc = numpy.radians(decCenter)
-        ra, dec = sampleFocus(size, rc, dc, radius)
+        rc = np.radians(raCenter)
+        dc = np.radians(decCenter)
+        ra, dec = sampleFocus(size, rc, dc, radius, rng=rng)
 
     # Typical colors
     umg = 1.5
@@ -244,7 +256,7 @@ def makeStarTestDB(filename='testDatabase.db', size=1000, seedVal=None,
     rmi = 1.0
     imz = 0.45
     zmy = 0.3
-    mag_norm = random(size)*6. + 18.
+    mag_norm = rng.random_sample(size)*6. + 18.
     # assume mag norm is g-band (which is close to true)
     umag = mag_norm + umg
     gmag = mag_norm
@@ -252,18 +264,18 @@ def makeStarTestDB(filename='testDatabase.db', size=1000, seedVal=None,
     imag = rmag - rmi
     zmag = imag - imz
     ymag = zmag - zmy
-    radVel = random(size)*50. - 25.
-    pmRa = random(size)*4./(1000*3600.)  # deg/yr
-    pmDec = random(size)*4./(1000*3600.)  # deg/yr
-    parallax = random(size)*1.0  # milliarcseconds per year
+    radVel = rng.random_sample(size)*50. - 25.
+    pmRa = rng.random_sample(size)*4./(1000*3600.)  # deg/yr
+    pmDec = rng.random_sample(size)*4./(1000*3600.)  # deg/yr
+    parallax = rng.random_sample(size)*1.0  # milliarcseconds per year
     for i in xrange(size):
-        period = random()*490. + 10.
-        amp = random()*5. + 0.2
+        period = rng.random_sample(1)[0]*490. + 10.
+        amp = rng.random_sample(1)[0]*5. + 0.2
         varParam = {'varMethodName': 'testVar', 'pars': {'period': period, 'amplitude': amp}}
         paramStr = json.dumps(varParam)
         qstr = '''INSERT INTO stars VALUES (%i, %f, %f, %f, %f, %f, %f,
                %f, %f, %f, %f, %.15f, %.15f, %.15f, '%s')''' % \
-               (i, numpy.degrees(ra[i]), numpy.degrees(dec[i]), umag[i], gmag[i], rmag[i],
+               (i, np.degrees(ra[i]), np.degrees(dec[i]), umag[i], gmag[i], rmag[i],
                 imag[i], zmag[i], ymag[i], mag_norm[i], radVel[i], pmRa[i], pmDec[i], parallax[i],
                 paramStr)
 
@@ -316,7 +328,7 @@ def makePhoSimTestDB(filename='PhoSimTestDatabase.db', size=1000, seedVal=32, ra
     agn_sed = 'agn.spec'
     star_seds = ['km20_5750.fits_g40_5790', 'm2.0Full.dat', 'bergeron_6500_85.dat_6700']
 
-    numpy.random.seed(seedVal)
+    rng = np.random.RandomState(seedVal)
 
     if displacedRA is not None and displacedDec is not None:
         if len(displacedRA) != len(displacedDec):
@@ -330,7 +342,7 @@ def makePhoSimTestDB(filename='PhoSimTestDatabase.db', size=1000, seedVal=32, ra
 
     # create the ObservationMetaData object
     mjd = 52000.0
-    alt = numpy.pi/2.0
+    alt = np.pi/2.0
     az = 0.0
 
     testSite = Site(name='LSST')
@@ -339,9 +351,9 @@ def makePhoSimTestDB(filename='PhoSimTestDatabase.db', size=1000, seedVal=32, ra
     rotTel = _getRotTelPos(centerRA, centerDec, obsTemp, 0.0)
     rotSkyPos = _getRotSkyPos(centerRA, centerDec, obsTemp, rotTel)
 
-    obs_metadata = ObservationMetaData(pointingRA=numpy.degrees(centerRA),
-                                       pointingDec=numpy.degrees(centerDec),
-                                       rotSkyPos=numpy.degrees(rotSkyPos),
+    obs_metadata = ObservationMetaData(pointingRA=np.degrees(centerRA),
+                                       pointingDec=np.degrees(centerDec),
+                                       rotSkyPos=np.degrees(rotSkyPos),
                                        bandpassName=bandpass,
                                        mjd=mjd,
                                        boundType = 'circle', boundLength = 2.0*radius,
@@ -352,7 +364,7 @@ def makePhoSimTestDB(filename='PhoSimTestDatabase.db', size=1000, seedVal=32, ra
     sun_alt = -90.0
 
     moon_ra, moon_dec = raDecFromAltAz(moon_alt, 0.0, obs_metadata)
-    dist2moon = haversine(numpy.radians(moon_ra), numpy.radians(moon_dec),
+    dist2moon = haversine(np.radians(moon_ra), np.radians(moon_dec),
                           obs_metadata._pointingRA, obs_metadata._pointingDec)
 
     obs_metadata.OpsimMetaData = {'moonra': moon_ra,
@@ -360,7 +372,7 @@ def makePhoSimTestDB(filename='PhoSimTestDatabase.db', size=1000, seedVal=32, ra
                                   'moonalt': moon_alt,
                                   'sunalt': sun_alt,
                                   'dist2moon': dist2moon,
-                                  'rottelpos': numpy.degrees(rotTel)}
+                                  'rottelpos': np.degrees(rotTel)}
 
     # Now begin building the database.
     # First create the tables.
@@ -414,87 +426,87 @@ def makePhoSimTestDB(filename='PhoSimTestDatabase.db', size=1000, seedVal=32, ra
 
     # Now generate the data to be stored in the tables.
 
-    rr = numpy.random.sample(size)*numpy.radians(radius)
-    theta = numpy.random.sample(size)*2.0*numpy.pi
+    rr = rng.random_sample(size)*np.radians(radius)
+    theta = rng.random_sample(size)*2.0*np.pi
 
     if displacedRA is None:
-        ra = numpy.degrees(centerRA + rr*numpy.cos(theta))
+        ra = np.degrees(centerRA + rr*np.cos(theta))
     else:
-        ra = numpy.degrees(centerRA) + displacedRA
+        ra = np.degrees(centerRA) + displacedRA
 
     if displacedDec is None:
-        dec = numpy.degrees(centerDec + rr*numpy.sin(theta))
+        dec = np.degrees(centerDec + rr*np.sin(theta))
     else:
-        dec = numpy.degrees(centerDec) + displacedDec
+        dec = np.degrees(centerDec) + displacedDec
 
-    bra = numpy.radians(ra+numpy.random.sample(size)*0.01*radius)
-    bdec = numpy.radians(dec+numpy.random.sample(size)*0.01*radius)
-    dra = numpy.radians(ra + numpy.random.sample(size)*0.01*radius)
-    ddec = numpy.radians(dec + numpy.random.sample(size)*0.01*radius)
-    agnra = numpy.radians(ra + numpy.random.sample(size)*0.01*radius)
-    agndec = numpy.radians(dec + numpy.random.sample(size)*0.01*radius)
+    bra = np.radians(ra+rng.random_sample(size)*0.01*radius)
+    bdec = np.radians(dec+rng.random_sample(size)*0.01*radius)
+    dra = np.radians(ra + rng.random_sample(size)*0.01*radius)
+    ddec = np.radians(dec + rng.random_sample(size)*0.01*radius)
+    agnra = np.radians(ra + rng.random_sample(size)*0.01*radius)
+    agndec = np.radians(dec + rng.random_sample(size)*0.01*radius)
 
-    magnorm_bulge = numpy.random.sample(size)*4.0 + 17.0
-    magnorm_disk = numpy.random.sample(size)*5.0 + 17.0
-    magnorm_agn = numpy.random.sample(size)*5.0 + 17.0
-    b_b = numpy.random.sample(size)*0.2
-    a_b = b_b+numpy.random.sample(size)*0.05
-    b_d = numpy.random.sample(size)*0.5
-    a_d = b_d+numpy.random.sample(size)*0.1
+    magnorm_bulge = rng.random_sample(size)*4.0 + 17.0
+    magnorm_disk = rng.random_sample(size)*5.0 + 17.0
+    magnorm_agn = rng.random_sample(size)*5.0 + 17.0
+    b_b = rng.random_sample(size)*0.2
+    a_b = b_b+rng.random_sample(size)*0.05
+    b_d = rng.random_sample(size)*0.5
+    a_d = b_d+rng.random_sample(size)*0.1
 
-    BulgeHalfLightRadius = numpy.random.sample(size)*0.2
-    DiskHalfLightRadius = numpy.random.sample(size)*0.5
+    BulgeHalfLightRadius = rng.random_sample(size)*0.2
+    DiskHalfLightRadius = rng.random_sample(size)*0.5
 
-    pa_bulge = numpy.random.sample(size)*360.0
-    pa_disk = numpy.random.sample(size)*360.0
+    pa_bulge = rng.random_sample(size)*360.0
+    pa_disk = rng.random_sample(size)*360.0
 
-    av_b = numpy.random.sample(size)*0.4
-    av_d = numpy.random.sample(size)*0.4
-    rv_b = numpy.random.sample(size)*0.1 + 3.0
-    rv_d = numpy.random.sample(size)*0.1 + 3.0
+    av_b = rng.random_sample(size)*0.4
+    av_d = rng.random_sample(size)*0.4
+    rv_b = rng.random_sample(size)*0.1 + 3.0
+    rv_d = rng.random_sample(size)*0.1 + 3.0
 
-    u_ab = numpy.random.sample(size)*4.0 + 17.0
-    g_ab = numpy.random.sample(size)*4.0 + 17.0
-    r_ab = numpy.random.sample(size)*4.0 + 17.0
-    i_ab = numpy.random.sample(size)*4.0 + 17.0
-    z_ab = numpy.random.sample(size)*4.0 + 17.0
-    y_ab = numpy.random.sample(size)*4.0 + 17.0
-    redshift = numpy.random.sample(size)*2.0
+    u_ab = rng.random_sample(size)*4.0 + 17.0
+    g_ab = rng.random_sample(size)*4.0 + 17.0
+    r_ab = rng.random_sample(size)*4.0 + 17.0
+    i_ab = rng.random_sample(size)*4.0 + 17.0
+    z_ab = rng.random_sample(size)*4.0 + 17.0
+    y_ab = rng.random_sample(size)*4.0 + 17.0
+    redshift = rng.random_sample(size)*2.0
 
-    t0_mjd = mjd - numpy.random.sample(size)*1000.0
-    agn_tau = numpy.random.sample(size)*1000.0 + 1000.0
-    agnSeed = numpy.random.random_integers(low=2, high=4000, size=size)
-    agn_sfu = numpy.random.sample(size)
-    agn_sfg = numpy.random.sample(size)
-    agn_sfr = numpy.random.sample(size)
-    agn_sfi = numpy.random.sample(size)
-    agn_sfz = numpy.random.sample(size)
-    agn_sfy = numpy.random.sample(size)
+    t0_mjd = mjd - rng.random_sample(size)*1000.0
+    agn_tau = rng.random_sample(size)*1000.0 + 1000.0
+    agnSeed = rng.random_integers(low=2, high=4000, size=size)
+    agn_sfu = rng.random_sample(size)
+    agn_sfg = rng.random_sample(size)
+    agn_sfr = rng.random_sample(size)
+    agn_sfi = rng.random_sample(size)
+    agn_sfz = rng.random_sample(size)
+    agn_sfy = rng.random_sample(size)
 
-    rrStar = numpy.random.sample(size)*numpy.radians(radius)
-    thetaStar = numpy.random.sample(size)*2.0*numpy.pi
+    rrStar = rng.random_sample(size)*np.radians(radius)
+    thetaStar = rng.random_sample(size)*2.0*np.pi
 
     if displacedRA is None:
-        raStar = centerRA + rrStar*numpy.cos(thetaStar)
+        raStar = centerRA + rrStar*np.cos(thetaStar)
     else:
-        raStar = centerRA + numpy.radians(displacedRA)
+        raStar = centerRA + np.radians(displacedRA)
 
     if displacedDec is None:
-        decStar = centerDec + rrStar*numpy.sin(thetaStar)
+        decStar = centerDec + rrStar*np.sin(thetaStar)
     else:
-        decStar = centerDec + numpy.radians(displacedDec)
+        decStar = centerDec + np.radians(displacedDec)
 
-    raStar = numpy.degrees(raStar)
-    decStar = numpy.degrees(decStar)
+    raStar = np.degrees(raStar)
+    decStar = np.degrees(decStar)
 
-    magnormStar = numpy.random.sample(size)*4.0 + 17.0
-    mudecl = numpy.random.sample(size)*0.0001
-    mura = numpy.random.sample(size)*0.0001
-    galacticAv = numpy.random.sample(size)*0.05*3.1
-    vrad = numpy.random.sample(size)*1.0
-    parallax = 0.00045+numpy.random.sample(size)*0.00001
-    period = numpy.random.sample(size)*20.0
-    amp = numpy.random.sample(size)*5.0
+    magnormStar = rng.random_sample(size)*4.0 + 17.0
+    mudecl = rng.random_sample(size)*0.0001
+    mura = rng.random_sample(size)*0.0001
+    galacticAv = rng.random_sample(size)*0.05*3.1
+    vrad = rng.random_sample(size)*1.0
+    parallax = 0.00045+rng.random_sample(size)*0.00001
+    period = rng.random_sample(size)*20.0
+    amp = rng.random_sample(size)*5.0
 
     # write the data to the tables.
     for i in range(size):

--- a/python/lsst/sims/catalogs/utils/testUtils.py
+++ b/python/lsst/sims/catalogs/utils/testUtils.py
@@ -1,24 +1,27 @@
 import os
 import sqlite3
-from collections import OrderedDict
-from numpy.random import random, seed
-import numpy, json
+from numpy.random import random
+from numpy.random import seed
+import numpy
+import json
 
 from lsst.sims.utils import ObservationMetaData
 from lsst.sims.catalogs.db import CatalogDBObject
-from lsst.sims.utils import _raDecFromAltAz, _getRotSkyPos, _getRotTelPos, Site, \
-                            raDecFromAltAz, haversine
+from lsst.sims.utils import (_raDecFromAltAz, _getRotSkyPos, _getRotTelPos, Site,
+                             raDecFromAltAz, haversine)
 
 __all__ = ["getOneChunk", "writeResult", "sampleSphere", "myTestGals",
            "makeGalTestDB", "myTestStars", "makeStarTestDB", "makePhoSimTestDB"]
+
 
 def getOneChunk(results):
     try:
         chunk = results.next()
     except StopIteration:
-        raise RuntimeError("No results were returned.  Cannot run tests.  Try increasing the size of the"+
+        raise RuntimeError("No results were returned.  Cannot run tests.  Try increasing the size of the"
                            " test database")
     return chunk
+
 
 def writeResult(result, fname):
     fh = open(fname, 'w')
@@ -31,14 +34,16 @@ def writeResult(result, fname):
             fh.write(",".join([str(chunk[name][i]) for name in chunk.dtype.names])+"\n")
     fh.close()
 
+
 def sampleSphere(size, ramin = 0., dra = 2.*numpy.pi):
-    #From Shao 1996: "Spherical Sampling by Archimedes' Theorem"
+    # From Shao 1996: "Spherical Sampling by Archimedes' Theorem"
     ra = random(size)*dra
     ra += ramin
     ra %= 2*numpy.pi
     z = random(size)*2. - 1.
     dec = numpy.arccos(z) - numpy.pi/2.
     return ra, dec
+
 
 def sampleFocus(size, raCenter, decCenter, radius):
     """
@@ -60,11 +65,12 @@ def sampleFocus(size, raCenter, decCenter, radius):
 
     return ra, dec
 
+
 class myTestGals(CatalogDBObject):
     objid = 'testgals'
     tableid = 'galaxies'
     idColKey = 'id'
-    #Make this implausibly large?
+    # Make this implausibly large?
     appendint = 1022
     objectTypeId = 45
     driver = 'sqlite'
@@ -88,10 +94,11 @@ class myTestGals(CatalogDBObject):
                ('a_disk', None),
                ('b_disk', None),
                ('a_bulge', None),
-               ('b_bulge', None),]
+               ('b_bulge', None)]
+
 
 def makeGalTestDB(filename='testDatabase.db', size=1000, seedVal=None,
-    raCenter=None, decCenter=None, radius=None, **kwargs):
+                  raCenter=None, decCenter=None, radius=None, **kwargs):
     """
     Make a test database to serve information to the myTestGals object
     @param size: Number of rows in the database
@@ -107,10 +114,10 @@ def makeGalTestDB(filename='testDatabase.db', size=1000, seedVal=None,
     c = conn.cursor()
     try:
         c.execute('''CREATE TABLE galaxies
-                     (id int, ra real, decl real, umag real, gmag real, rmag real,
-                     imag real, zmag real, ymag real,
-                     mag_norm_agn real, mag_norm_bulge real, mag_norm_disk real,
-                     redshift real, a_disk real, b_disk real, a_bulge real, b_bulge real, varParamStr text)''')
+                  (id int, ra real, decl real, umag real, gmag real, rmag real,
+                  imag real, zmag real, ymag real,
+                  mag_norm_agn real, mag_norm_bulge real, mag_norm_disk real,
+                  redshift real, a_disk real, b_disk real, a_bulge real, b_bulge real, varParamStr text)''')
         conn.commit()
     except:
         raise RuntimeError("Error creating database.")
@@ -122,9 +129,8 @@ def makeGalTestDB(filename='testDatabase.db', size=1000, seedVal=None,
     else:
         rc = numpy.radians(raCenter)
         dc = numpy.radians(decCenter)
-        rr = numpy.radians(radius)
         ra, dec = sampleFocus(size, rc, dc, radius)
-    #Typical colors for main sequece stars
+    # Typical colors for main sequece stars
     umg = 1.5
     gmr = 0.65
     rmi = 1.0
@@ -136,14 +142,14 @@ def makeGalTestDB(filename='testDatabase.db', size=1000, seedVal=None,
     redshift = random(size)*2.5
 
     a_disk = random(size)*2.
-    flatness = random(size)*0.8 # To prevent linear galaxies
+    flatness = random(size)*0.8  # To prevent linear galaxies
     b_disk = a_disk*(1 - flatness)
 
     a_bulge = random(size)*1.5
     flatness = random(size)*0.5
     b_bulge = a_bulge*(1 - flatness)
 
-    #assume mag norm is g-band (which is close to true)
+    # assume mag norm is g-band (which is close to true)
     mag_norm = -2.5*numpy.log10(numpy.power(10, mag_norm_disk/-2.5) + numpy.power(10, mag_norm_bulge/-2.5) +
                                 numpy.power(10, mag_norm_agn/-2.5))
     umag = mag_norm + umg
@@ -155,25 +161,28 @@ def makeGalTestDB(filename='testDatabase.db', size=1000, seedVal=None,
     for i in xrange(size):
         period = random()*490. + 10.
         amp = random()*5. + 0.2
-        varParam = {'varMethodName':'testVar', 'pars':{'period':period, 'amplitude':amp}}
+        varParam = {'varMethodName': 'testVar', 'pars': {'period': period, 'amplitude': amp}}
         paramStr = json.dumps(varParam)
         qstr = '''INSERT INTO galaxies VALUES (%i, %f, %f, %f,
                      %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f,
-                     %f, %f, '%s')'''%\
-                   (i, numpy.degrees(ra[i]), numpy.degrees(dec[i]), umag[i], gmag[i], rmag[i], imag[i],
-                   zmag[i], ymag[i], mag_norm_agn[i], mag_norm_bulge[i], mag_norm_disk[i], redshift[i],
-                   a_disk[i], b_disk[i], a_bulge[i], b_bulge[i], paramStr)
+                     %f, %f, '%s')''' % \
+               (i, numpy.degrees(ra[i]), numpy.degrees(dec[i]), umag[i], gmag[i], rmag[i], imag[i],
+                zmag[i], ymag[i], mag_norm_agn[i], mag_norm_bulge[i], mag_norm_disk[i], redshift[i],
+                a_disk[i], b_disk[i], a_bulge[i], b_bulge[i], paramStr)
+
         c.execute(qstr)
+
     c.execute('''CREATE INDEX gal_ra_idx ON galaxies (ra)''')
     c.execute('''CREATE INDEX gal_dec_idx ON galaxies (decl)''')
     conn.commit()
     conn.close()
 
+
 class myTestStars(CatalogDBObject):
     objid = 'teststars'
     tableid = 'stars'
     idColKey = 'id'
-    #Make this implausibly large?
+    # Make this implausibly large?
     appendint = 1023
     objectTypeId = 46
     driver = 'sqlite'
@@ -194,8 +203,9 @@ class myTestStars(CatalogDBObject):
                ('ymag', None),
                ('magNorm', 'mag_norm', float)]
 
+
 def makeStarTestDB(filename='testDatabase.db', size=1000, seedVal=None,
-    raCenter=None, decCenter=None, radius=None, **kwargs):
+                   raCenter=None, decCenter=None, radius=None, **kwargs):
     """
     Make a test database to serve information to the myTestStars object
     @param size: Number of rows in the database
@@ -226,17 +236,16 @@ def makeStarTestDB(filename='testDatabase.db', size=1000, seedVal=None,
     else:
         rc = numpy.radians(raCenter)
         dc = numpy.radians(decCenter)
-        rr = numpy.radians(radius)
         ra, dec = sampleFocus(size, rc, dc, radius)
 
-    #Typical colors
+    # Typical colors
     umg = 1.5
     gmr = 0.65
     rmi = 1.0
     imz = 0.45
     zmy = 0.3
     mag_norm = random(size)*6. + 18.
-    #assume mag norm is g-band (which is close to true)
+    # assume mag norm is g-band (which is close to true)
     umag = mag_norm + umg
     gmag = mag_norm
     rmag = gmag - gmr
@@ -244,23 +253,27 @@ def makeStarTestDB(filename='testDatabase.db', size=1000, seedVal=None,
     zmag = imag - imz
     ymag = zmag - zmy
     radVel = random(size)*50. - 25.
-    pmRa = random(size)*4./(1000*3600.) # deg/yr
-    pmDec = random(size)*4./(1000*3600.) # deg/yr
-    parallax = random(size)*1.0 #milliarcseconds per year
+    pmRa = random(size)*4./(1000*3600.)  # deg/yr
+    pmDec = random(size)*4./(1000*3600.)  # deg/yr
+    parallax = random(size)*1.0  # milliarcseconds per year
     for i in xrange(size):
         period = random()*490. + 10.
         amp = random()*5. + 0.2
-        varParam = {'varMethodName':'testVar', 'pars':{'period':period, 'amplitude':amp}}
+        varParam = {'varMethodName': 'testVar', 'pars': {'period': period, 'amplitude': amp}}
         paramStr = json.dumps(varParam)
-        qstr = '''INSERT INTO stars VALUES (%i, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %.15f, %.15f, %.15f, '%s')'''%\
-                  (i, numpy.degrees(ra[i]), numpy.degrees(dec[i]), umag[i], gmag[i], rmag[i],
-                   imag[i], zmag[i], ymag[i], mag_norm[i], radVel[i], pmRa[i], pmDec[i], parallax[i],
-                   paramStr)
+        qstr = '''INSERT INTO stars VALUES (%i, %f, %f, %f, %f, %f, %f,
+               %f, %f, %f, %f, %.15f, %.15f, %.15f, '%s')''' % \
+               (i, numpy.degrees(ra[i]), numpy.degrees(dec[i]), umag[i], gmag[i], rmag[i],
+                imag[i], zmag[i], ymag[i], mag_norm[i], radVel[i], pmRa[i], pmDec[i], parallax[i],
+                paramStr)
+
         c.execute(qstr)
+
     c.execute('''CREATE INDEX star_ra_idx ON stars (ra)''')
     c.execute('''CREATE INDEX star_dec_idx ON stars (decl)''')
     conn.commit()
     conn.close()
+
 
 def makePhoSimTestDB(filename='PhoSimTestDatabase.db', size=1000, seedVal=32, radius=0.1,
                      displacedRA=None, displacedDec=None,
@@ -298,23 +311,24 @@ def makePhoSimTestDB(filename='PhoSimTestDatabase.db', size=1000, seedVal=32, ra
     if os.path.exists(filename):
         os.unlink(filename)
 
-    #just an example of some valid SED file names
-    galaxy_seds = ['Const.80E07.02Z.spec','Inst.80E07.002Z.spec','Burst.19E07.0005Z.spec']
+    # just an example of some valid SED file names
+    galaxy_seds = ['Const.80E07.02Z.spec', 'Inst.80E07.002Z.spec', 'Burst.19E07.0005Z.spec']
     agn_sed = 'agn.spec'
-    star_seds = ['km20_5750.fits_g40_5790','m2.0Full.dat','bergeron_6500_85.dat_6700']
+    star_seds = ['km20_5750.fits_g40_5790', 'm2.0Full.dat', 'bergeron_6500_85.dat_6700']
 
     numpy.random.seed(seedVal)
 
     if displacedRA is not None and displacedDec is not None:
         if len(displacedRA) != len(displacedDec):
-            raise RuntimeError("WARNING in makePhoSimTestDB displacedRA and displacedDec have different lengths")
+            raise RuntimeError("WARNING in makePhoSimTestDB displacedRA and "
+                               "displacedDec have different lengths")
 
     if displacedRA is not None:
         size = len(displacedRA)
     elif displacedDec is not None:
         size = len(displacedDec)
 
-    #create the ObservationMetaData object
+    # create the ObservationMetaData object
     mjd = 52000.0
     alt = numpy.pi/2.0
     az = 0.0
@@ -348,8 +362,8 @@ def makePhoSimTestDB(filename='PhoSimTestDatabase.db', size=1000, seedVal=32, ra
                                   'dist2moon': dist2moon,
                                   'rottelpos': numpy.degrees(rotTel)}
 
-    #Now begin building the database.
-    #First create the tables.
+    # Now begin building the database.
+    # First create the tables.
     conn = sqlite3.connect(filename)
     c = conn.cursor()
     try:
@@ -393,11 +407,12 @@ def makePhoSimTestDB(filename='PhoSimTestDatabase.db', size=1000, seedVal=32, ra
     try:
         c.execute('''CREATE TABLE StarAllForceseek
                   (simobjid int, ra real, decl real, magNorm real,
-                  mudecl real, mura real, galacticAv real, vrad real, varParamStr text, sedFilename text, parallax real)''')
+                  mudecl real, mura real, galacticAv real, vrad real, varParamStr text,
+                  sedFilename text, parallax real)''')
     except:
         raise RuntimeError("Error creating StarAllForceseek table.")
 
-    #Now generate the data to be stored in the tables.
+    # Now generate the data to be stored in the tables.
 
     rr = numpy.random.sample(size)*numpy.radians(radius)
     theta = numpy.random.sample(size)*2.0*numpy.pi
@@ -406,7 +421,6 @@ def makePhoSimTestDB(filename='PhoSimTestDatabase.db', size=1000, seedVal=32, ra
         ra = numpy.degrees(centerRA + rr*numpy.cos(theta))
     else:
         ra = numpy.degrees(centerRA) + displacedRA
-
 
     if displacedDec is None:
         dec = numpy.degrees(centerDec + rr*numpy.sin(theta))
@@ -444,7 +458,7 @@ def makePhoSimTestDB(filename='PhoSimTestDatabase.db', size=1000, seedVal=32, ra
     r_ab = numpy.random.sample(size)*4.0 + 17.0
     i_ab = numpy.random.sample(size)*4.0 + 17.0
     z_ab = numpy.random.sample(size)*4.0 + 17.0
-    y_ab = numpy.random.sample(size)*4.0 +17.0
+    y_ab = numpy.random.sample(size)*4.0 + 17.0
     redshift = numpy.random.sample(size)*2.0
 
     t0_mjd = mjd - numpy.random.sample(size)*1000.0
@@ -482,21 +496,23 @@ def makePhoSimTestDB(filename='PhoSimTestDatabase.db', size=1000, seedVal=32, ra
     period = numpy.random.sample(size)*20.0
     amp = numpy.random.sample(size)*5.0
 
-    #write the data to the tables.
+    # write the data to the tables.
     for i in range(size):
 
         cmd = '''INSERT INTO galaxy_bulge VALUES (%i, %i, %f, %f, %f, %f, %f,
-                     '%s', %f, %f, %f, %i, '%s', %f, %f, %f, %f, %f, %f, %f, %f, %f, %f)''' %\
-                     (i, i, bra[i], bdec[i], ra[i], dec[i], magnorm_bulge[i], galaxy_seds[i%len(galaxy_seds)],
-                     a_b[i], b_b[i], pa_bulge[i], 4, 'CCM', av_b[i], rv_b[i], u_ab[i], g_ab[i],
-                     r_ab[i], i_ab[i], z_ab[i], y_ab[i], redshift[i], BulgeHalfLightRadius[i])
+              '%s', %f, %f, %f, %i, '%s', %f, %f, %f, %f, %f, %f, %f, %f, %f, %f)''' % \
+              (i, i, bra[i], bdec[i], ra[i], dec[i], magnorm_bulge[i], galaxy_seds[i%len(galaxy_seds)],
+               a_b[i], b_b[i], pa_bulge[i], 4, 'CCM', av_b[i], rv_b[i], u_ab[i], g_ab[i],
+               r_ab[i], i_ab[i], z_ab[i], y_ab[i], redshift[i], BulgeHalfLightRadius[i])
+
         c.execute(cmd)
 
-        varParam = {'varMethodName':'applyAgn',
-                    'pars':{'agn_tau':round(agn_tau[i],4), 't0_mjd':round(t0_mjd[i],4),
-                    'agn_sfu':round(agn_sfu[i],4), 'agn_sfg':round(agn_sfg[i],4), 'agn_sfr':round(agn_sfr[i],4),
-                    'agn_sfi':round(agn_sfi[i],4), 'agn_sfz':round(agn_sfz[i],4), 'agn_sfy':round(agn_sfy[i],4),
-                    'seed':int(agnSeed[i])}}
+        varParam = {'varMethodName': 'applyAgn',
+                    'pars': {'agn_tau': round(agn_tau[i], 4), 't0_mjd': round(t0_mjd[i], 4),
+                             'agn_sfu': round(agn_sfu[i], 4), 'agn_sfg': round(agn_sfg[i], 4),
+                             'agn_sfr': round(agn_sfr[i], 4), 'agn_sfi': round(agn_sfi[i], 4),
+                             'agn_sfz': round(agn_sfz[i], 4), 'agn_sfy': round(agn_sfy[i], 4),
+                             'seed': int(agnSeed[i])}}
 
         paramStr = json.dumps(varParam)
 
@@ -507,32 +523,33 @@ def makePhoSimTestDB(filename='PhoSimTestDatabase.db', size=1000, seedVal=32, ra
                                             '%s', %f, %f,
                                             '%s', %f, %f,
                                             %f, %f, %f, %f, %f, %f,
-                                            %f, %f, %f)''' %\
-                     (i, i, ra[i], dec[i], bra[i], bdec[i], dra[i], ddec[i], agnra[i], agndec[i],
-                     magnorm_bulge[i], magnorm_disk[i], magnorm_agn[i],
-                     galaxy_seds[i%len(galaxy_seds)], galaxy_seds[i%len(galaxy_seds)], agn_sed,
-                     paramStr,
-                     a_b[i], b_b[i], pa_bulge[i], 4,
-                     a_d[i], b_d[i], pa_disk[i], 1,
-                     'CCM', av_b[i], rv_b[i],
-                     'CCM', av_d[i], rv_d[i],
-                     u_ab[i], g_ab[i], r_ab[i], i_ab[i], z_ab[i], y_ab[i], redshift[i],
-                     BulgeHalfLightRadius[i], DiskHalfLightRadius[i])
+                                            %f, %f, %f)''' % \
+              (i, i, ra[i], dec[i], bra[i], bdec[i], dra[i], ddec[i], agnra[i], agndec[i],
+               magnorm_bulge[i], magnorm_disk[i], magnorm_agn[i],
+               galaxy_seds[i%len(galaxy_seds)], galaxy_seds[i%len(galaxy_seds)], agn_sed,
+               paramStr,
+               a_b[i], b_b[i], pa_bulge[i], 4,
+               a_d[i], b_d[i], pa_disk[i], 1,
+               'CCM', av_b[i], rv_b[i],
+               'CCM', av_d[i], rv_d[i],
+               u_ab[i], g_ab[i], r_ab[i], i_ab[i], z_ab[i], y_ab[i], redshift[i],
+               BulgeHalfLightRadius[i], DiskHalfLightRadius[i])
         c.execute(cmd)
 
         cmd = '''INSERT INTO galaxy_agn VALUES (%i, %i, %f, %f, %f, %f, %f, '%s', '%s',
-                                               %f, %f, %f, %f, %f, %f, %f)''' %\
-                                               (i, i, agnra[i], agndec[i], ra[i], dec[i],
-                                               magnorm_agn[i], agn_sed, paramStr,
-                                               u_ab[i], g_ab[i], r_ab[i], i_ab[i],
-                                               z_ab[i], y_ab[i], redshift[i])
+              %f, %f, %f, %f, %f, %f, %f)''' % \
+              (i, i, agnra[i], agndec[i], ra[i], dec[i],
+               magnorm_agn[i], agn_sed, paramStr,
+               u_ab[i], g_ab[i], r_ab[i], i_ab[i],
+               z_ab[i], y_ab[i], redshift[i])
+
         c.execute(cmd)
 
-        varParam = {'varMethodName':'testVar', 'pars':{'period':period[i], 'amplitude':amp[i]}}
+        varParam = {'varMethodName': 'testVar', 'pars': {'period': period[i], 'amplitude': amp[i]}}
         paramStr = json.dumps(varParam)
         cmd = '''INSERT INTO StarAllForceseek VALUES (%i, %f, %f, %f, %f, %f, %f, %f, '%s', '%s', %f)''' %\
-                  (i, raStar[i], decStar[i], magnormStar[i], mudecl[i], mura[i],
-                  galacticAv[i], vrad[i], paramStr, star_seds[i%len(star_seds)], parallax[i])
+              (i, raStar[i], decStar[i], magnormStar[i], mudecl[i], mura[i],
+               galacticAv[i], vrad[i], paramStr, star_seds[i%len(star_seds)], parallax[i])
 
         c.execute(cmd)
 

--- a/python/lsst/sims/catalogs/utils/testUtils.py
+++ b/python/lsst/sims/catalogs/utils/testUtils.py
@@ -341,12 +341,12 @@ def makePhoSimTestDB(filename='PhoSimTestDatabase.db', size=1000, seedVal=32, ra
     dist2moon = haversine(numpy.radians(moon_ra), numpy.radians(moon_dec),
                           obs_metadata._pointingRA, obs_metadata._pointingDec)
 
-    obs_metadata.phoSimMetaData = {'Opsim_moonra': moon_ra,
-                                   'Opsim_moondec': moon_dec,
-                                   'Opsim_moonalt': moon_alt,
-                                   'Opsim_sunalt': sun_alt,
-                                   'Opsim_dist2moon': dist2moon,
-                                   'Opsim_rottelpos': numpy.degrees(rotTel)}
+    obs_metadata.phoSimMetaData = {'moonra': moon_ra,
+                                   'moondec': moon_dec,
+                                   'moonalt': moon_alt,
+                                   'sunalt': sun_alt,
+                                   'dist2moon': dist2moon,
+                                   'rottelpos': numpy.degrees(rotTel)}
 
     #Now begin building the database.
     #First create the tables.

--- a/python/lsst/sims/catalogs/utils/testUtils.py
+++ b/python/lsst/sims/catalogs/utils/testUtils.py
@@ -341,12 +341,12 @@ def makePhoSimTestDB(filename='PhoSimTestDatabase.db', size=1000, seedVal=32, ra
     dist2moon = haversine(numpy.radians(moon_ra), numpy.radians(moon_dec),
                           obs_metadata._pointingRA, obs_metadata._pointingDec)
 
-    obs_metadata.phoSimMetaData = {'moonra': moon_ra,
-                                   'moondec': moon_dec,
-                                   'moonalt': moon_alt,
-                                   'sunalt': sun_alt,
-                                   'dist2moon': dist2moon,
-                                   'rottelpos': numpy.degrees(rotTel)}
+    obs_metadata.OpsimMetaData = {'moonra': moon_ra,
+                                  'moondec': moon_dec,
+                                  'moonalt': moon_alt,
+                                  'sunalt': sun_alt,
+                                  'dist2moon': dist2moon,
+                                  'rottelpos': numpy.degrees(rotTel)}
 
     #Now begin building the database.
     #First create the tables.


### PR DESCRIPTION
A new PhoSim InstanceCatalog API has been published here

https://bitbucket.org/phosim/phosim_release/wiki/Instance%20Catalog

This required a re-working of our CatSim-PhoSim interface.  Under this pull request, whenever a user creates an ObservationMetaData using the ObservationMetaDataGenerator, all of the OpSim columns associated with the pointing will be stored in a dict called `OpsimMetaData`.  The mapping between these OpSim columns and the header parameters expected by PhoSim will be handled by a dict called `phoSimHeaderMap` which is assigned to the InstanceCatalog before writing it.  If no `phoSimHeaderMap` is specified, an error is thrown whose message explains the way the header map should work.  Even if users do not want to map any extra columns (i.e. anything beyond RA, Dec, Alt, Az, MJD, rotSkyPos, and filter, which ObservationMetaData handles automatically), they must specify an empty dict as the `phoSimHeaderMap`.  This is to prevent users from doing something they did not intend (since PhoSim will accept nonsense or incomplete header parameters without failing).

This required changes to

sims_utils
sims_catalogs
sims_catUtils
sims_GalSimInterface
