### PR TITLE
U/danielsf/pre screen

### DIFF
--- a/python/lsst/sims/catalogs/db/CompoundCatalogDBObject.py
+++ b/python/lsst/sims/catalogs/db/CompoundCatalogDBObject.py
@@ -80,26 +80,6 @@ class CompoundCatalogDBObject(CatalogDBObject):
         self.raColName = dbo.raColName
         self.decColName = dbo.decColName
 
-        if hasattr(dbo, 'driver'):
-            driver = dbo.driver
-        else:
-            driver = None
-
-        if hasattr(dbo, 'host'):
-            host = dbo.host
-        else:
-            host = None
-
-        if hasattr(dbo, 'port'):
-            port = dbo.port
-        else:
-            port = None
-
-        if hasattr(dbo, 'verbose'):
-            verbose = dbo.verbose
-        else:
-            verbose = False
-
         super(CompoundCatalogDBObject, self).__init__(connection=dbo.connection)
 
     def _make_columns(self):

--- a/python/lsst/sims/catalogs/db/CompoundCatalogDBObject.py
+++ b/python/lsst/sims/catalogs/db/CompoundCatalogDBObject.py
@@ -1,8 +1,7 @@
-import numpy
-from collections import OrderedDict
 from lsst.sims.catalogs.db import CatalogDBObject
 
 __all__ = ["CompoundCatalogDBObject"]
+
 
 class CompoundCatalogDBObject(CatalogDBObject):
     """
@@ -74,7 +73,7 @@ class CompoundCatalogDBObject(CatalogDBObject):
         dbo = self._dbObjectClassList[0](connection=connection)
         # need to instantiate the first one because sometimes
         # idColKey is not defined until instantiation
-        # (see GalaxyTileObj in sims_catUtils/../baseCatalogModels/GalaxyModels.py
+        # (see GalaxyTileObj in sims_catUtils/../baseCatalogModels/GalaxyModels.py)
 
         self.tableid = dbo.tableid
         self.idColKey = dbo.idColKey
@@ -103,7 +102,6 @@ class CompoundCatalogDBObject(CatalogDBObject):
 
         super(CompoundCatalogDBObject, self).__init__(connection=dbo.connection)
 
-
     def _make_columns(self):
         """
         Construct the self.columns member by concatenating the self.columns
@@ -111,11 +109,11 @@ class CompoundCatalogDBObject(CatalogDBObject):
         columns to identify them with their specific CatalogDBObjects.
         """
         column_names = []
-        self.columns= []
+        self.columns = []
         for dbo, dbName in zip(self._dbObjectClassList, self._nameList):
             for row in dbo.columns:
-                new_row=[ww for ww in row]
-                new_row[0]=str('%s_%s' % (dbName, row[0]))
+                new_row = [ww for ww in row]
+                new_row[0] = str('%s_%s' % (dbName, row[0]))
                 if new_row[1] is None:
                     new_row[1] = row[0]
                 self.columns.append(tuple(new_row))
@@ -131,10 +129,9 @@ class CompoundCatalogDBObject(CatalogDBObject):
                 # names like 'galaxytileid' in query_columns, but leaving 'galaxytileid'
                 # un-mangled in self.columns so that self.typeMap knows how to deal
                 # with it when it comes back.
-                if row[0] not in column_names and (row[1] is None or row[1]==row[0]):
+                if row[0] not in column_names and (row[1] is None or row[1] == row[0]):
                     self.columns.append(row)
                     column_names.append(row[0])
-
 
     def _make_dbTypeMap(self):
         """
@@ -147,7 +144,6 @@ class CompoundCatalogDBObject(CatalogDBObject):
                 if col not in self.dbTypeMap:
                     self.dbTypeMap[col] = dbo.dbTypeMap[col]
 
-
     def _make_dbDefaultValues(self):
         """
         Construct the self.dbDefaultValues member by concatenating the
@@ -157,7 +153,6 @@ class CompoundCatalogDBObject(CatalogDBObject):
         for dbo, dbName in zip(self._dbObjectClassList, self._nameList):
             for col in dbo.dbDefaultValues:
                 self.dbDefaultValues['%s_%s' % (dbName, col)] = dbo.dbDefaultValues[col]
-
 
     def _validate_input(self):
         """
@@ -200,41 +195,41 @@ class CompoundCatalogDBObject(CatalogDBObject):
                 if dbo.objid not in objidList:
                     objidList.append(dbo.objid)
                 else:
-                    raise RuntimeError('WARNING the objid %s ' % dbo.objid \
-                                         + 'is duplicated in your list of ' \
-                                         + 'CatalogDBObjects\n' \
-                                         + 'CompoundCatalogDBObject requires each' \
-                                         + ' CatalogDBObject have a unique objid\n')
+                    raise RuntimeError('The objid %s ' % dbo.objid +
+                                       'is duplicated in your list of ' +
+                                       'CatalogDBObjects\n' +
+                                       'CompoundCatalogDBObject requires each' +
+                                       ' CatalogDBObject have a unique objid\n')
 
         acceptable = True
         msg = ''
-        if len(hostList)>1:
+        if len(hostList) > 1:
             acceptable = False
             msg += ' hosts: ' + str(hostList) + '\n'
 
-        if len(databaseList)!=1:
+        if len(databaseList) != 1:
             acceptable = False
             msg += ' databases: ' + str(databaseList) + '\n'
 
-        if len(portList)>1:
+        if len(portList) > 1:
             acceptable = False
             msg += ' ports: ' + str(portList) + '\n'
 
-        if len(driverList)>1:
+        if len(driverList) > 1:
             acceptable = False
             msg += ' drivers: ' + str(driverList) + '\n'
 
-        if len(tableList)!=1:
+        if len(tableList) != 1:
             acceptable = False
             msg += ' tables: ' + str(tableList) + '\n'
 
         if not acceptable:
-            raise RuntimeError('The CatalogDBObjects fed to ' \
-                               + 'CompoundCatalogDBObject do not all ' \
-                               + 'query the same table:\n' \
-                               + msg)
+            raise RuntimeError('The CatalogDBObjects fed to ' +
+                               'CompoundCatalogDBObject do not all ' +
+                               'query the same table:\n' +
+                               msg)
 
-        if self._table_restriction is not None and len(tableList)>0:
+        if self._table_restriction is not None and len(tableList) > 0:
             if tableList[0] not in self._table_restriction:
-                raise RuntimeError("This CompoundCatalogDBObject does not support " \
-                                   + "the table '%s' " % tableList[0])
+                raise RuntimeError("This CompoundCatalogDBObject does not support " +
+                                   "the table '%s' " % tableList[0])

--- a/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
@@ -260,6 +260,8 @@ class CompoundInstanceCatalog(object):
             if len(row) > 1:
                 dbObjClassList = [self._dbo_list[ix] for ix in row]
                 catList = [instantiated_ic_list[ix] for ix in row]
+                for cat in catList:
+                    cat._pre_screen = True
 
                 # if a connection is already open to the database, use
                 # it rather than opening a new connection

--- a/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
@@ -1,5 +1,5 @@
 from __future__ import with_statement
-import numpy
+import numpy as np
 from lsst.sims.catalogs.db import CompoundCatalogDBObject
 
 
@@ -357,15 +357,15 @@ class CompoundInstanceCatalog(object):
                             if name not in chunk.dtype.fields:
                                 master_colnames[ix][iy] = name_map[ix][name]
 
-                    local_recarray = chunk[master_colnames[ix]].view(numpy.recarray)
+                    local_recarray = chunk[master_colnames[ix]].view(np.recarray)
 
                     local_recarray.flags['WRITEABLE'] = False  # so numpy does not raise a warning
                                                                # because it thinks we may accidentally
                                                                # write to this array
                     if new_dtype_list[ix] is None:
-                        new_dtype = numpy.dtype([tuple([dd.replace(catName+'_', '')] +
-                                                       [local_recarray.dtype[dd]])
-                                                for dd in master_colnames[ix]])
+                        new_dtype = np.dtype([tuple([dd.replace(catName+'_', '')] +
+                                                    [local_recarray.dtype[dd]])
+                                              for dd in master_colnames[ix]])
                         new_dtype_list[ix] = new_dtype
 
                     local_recarray.dtype = new_dtype_list[ix]

--- a/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
@@ -163,7 +163,7 @@ class InstanceCatalog(object):
     delimiter = ", "
     comment_char = "#"
     endline = "\n"
-    _pre_screen = False  # if true, write_catalog() will check database query resutls against
+    _pre_screen = False  # if true, write_catalog() will check database query results against
                          # cannot_be_null before calculating getter columns
 
     @classmethod

--- a/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
@@ -9,6 +9,7 @@ from lsst.sims.utils import ObservationMetaData
 
 __all__ = ["InstanceCatalog", "is_null"]
 
+
 def is_null(argument):
     """
     Return True if 'argument' is some null value
@@ -21,7 +22,7 @@ def is_null(argument):
     """
     if argument is None:
         return True
-    elif isinstance(argument,str) or isinstance(argument,unicode):
+    elif isinstance(argument, str) or isinstance(argument, unicode):
         if argument.strip().lower() == 'null':
             return True
         elif argument.strip().lower() == 'nan':
@@ -32,6 +33,7 @@ def is_null(argument):
         return True
 
     return False
+
 
 class InstanceCatalogMeta(type):
     """Meta class for registering instance catalogs.
@@ -156,8 +158,8 @@ class InstanceCatalog(object):
     column_outputs = None
     specFileMap = defaultSpecMap
     default_columns = []
-    cannot_be_null = [] # a list of columns which, if null, cause a row not to be printed by write_catalog()
-    default_formats = {'S':'%s', 'f':'%.4f', 'i':'%i'}
+    cannot_be_null = []  # a list of columns which, if null, cause a row not to be printed by write_catalog()
+    default_formats = {'S': '%s', 'f': '%.4f', 'i': '%i'}
     override_formats = {}
     transformations = {}
     delimiter = ", "
@@ -185,7 +187,6 @@ class InstanceCatalog(object):
             if hasattr(getattr(cls, getfunc), '_compound_column'):
                 return True
         return False
-
 
     def iter_column_names(self):
         """Iterate the column names, expanding any compound columns"""
@@ -237,7 +238,7 @@ class InstanceCatalog(object):
         self._column_origins = {}
 
         if obs_metadata is not None:
-            if not isinstance(obs_metadata,ObservationMetaData):
+            if not isinstance(obs_metadata, ObservationMetaData):
                 raise ValueError("You passed InstanceCatalog something that was not ObservationMetaData")
 
             self.obs_metadata = copy.deepcopy(obs_metadata)
@@ -255,7 +256,7 @@ class InstanceCatalog(object):
                     if col not in self._column_outputs:
                         self._column_outputs.append(col)
 
-        self._actually_calculated_columns =[] # a list of all the columns referenced by self.column_by_name
+        self._actually_calculated_columns = []  # a list of all the columns referenced by self.column_by_name
         self.constraint = constraint
 
         if specFileMap is not None:
@@ -300,7 +301,7 @@ class InstanceCatalog(object):
                 if columnName not in self._all_available_columns:
                     self._all_available_columns.append(columnName)
 
-        if not hasattr(self,'_column_outputs'):
+        if not hasattr(self, '_column_outputs'):
             self._column_outputs = []
 
             # because asking for a compound_column means asking for
@@ -311,7 +312,6 @@ class InstanceCatalog(object):
                     self._column_outputs.append(name)
 
         self._check_requirements()
-
 
     def _set_current_chunk(self, chunk, column_cache=None):
         """Set the current chunk and clear the column cache"""
@@ -329,13 +329,13 @@ class InstanceCatalog(object):
 
         for col_name in self.iter_column_names():
             # just call the column: this will log queries to the database.
-            col = self.column_by_name(col_name)
+            self.column_by_name(col_name)
 
         db_required_columns = list(self._current_chunk.referenced_columns)
 
         default_columns_set = set(el[0] for el in self.default_columns)
         required_columns_set = set(db_required_columns)
-        required_columns_with_defaults = default_columns_set&required_columns_set
+        required_columns_with_defaults = default_columns_set & required_columns_set
 
         self._set_current_chunk(saved_chunk, saved_cache)
 
@@ -344,12 +344,14 @@ class InstanceCatalog(object):
     def column_by_name(self, column_name, *args, **kwargs):
         """Given a column name, return the column data"""
 
-        if isinstance(self._current_chunk, _MimicRecordArray) and column_name not in self._actually_calculated_columns:
+        if (isinstance(self._current_chunk, _MimicRecordArray) and
+            column_name not in self._actually_calculated_columns):
+
             self._actually_calculated_columns.append(column_name)
 
         getfunc = "get_%s" % column_name
         if hasattr(self, getfunc):
-            function = getattr(self,getfunc)
+            function = getattr(self, getfunc)
 
             if self._column_origins_switch:
                 self._column_origins[column_name] = self._get_class_that_defined_method(function)
@@ -357,17 +359,18 @@ class InstanceCatalog(object):
             return function(*args, **kwargs)
         elif column_name in self._compound_column_names:
             getfunc = self._compound_column_names[column_name]
-            function = getattr(self,getfunc)
+            function = getattr(self, getfunc)
 
             if self._column_origins_switch and column_name:
                 self._column_origins[column_name] = self._get_class_that_defined_method(function)
 
             compound_column = function(*args, **kwargs)
             return compound_column[column_name]
-        elif isinstance(self._current_chunk, _MimicRecordArray) or column_name in self._current_chunk.dtype.names:
+        elif (isinstance(self._current_chunk, _MimicRecordArray) or
+              column_name in self._current_chunk.dtype.names):
 
             if self._column_origins_switch:
-                 self._column_origins[column_name] = 'the database'
+                self._column_origins[column_name] = 'the database'
 
             return self._current_chunk[column_name]
         else:
@@ -390,7 +393,7 @@ class InstanceCatalog(object):
             else:
                 self._active_columns.append(col)
 
-        self._column_origins_switch = False # do not want to log column origins any more
+        self._column_origins_switch = False  # do not want to log column origins any more
 
         if len(missing_cols) > 0:
             nodefault = []
@@ -431,12 +434,10 @@ class InstanceCatalog(object):
 
     def write_header(self, file_handle):
         column_names = list(self.iter_column_names())
-        templ = [self.comment_char,]
+        templ = [self.comment_char, ]
         templ += ["%s" for col in column_names]
-        file_handle.write("{0}".format(
-                self.comment_char + self.delimiter.join(column_names))
-                          + self.endline)
-
+        file_handle.write("{0}".format(self.comment_char + self.delimiter.join(column_names)) +
+                          self.endline)
 
     def write_catalog(self, filename, chunk_size=None,
                       write_header=True, write_mode='w'):
@@ -465,7 +466,6 @@ class InstanceCatalog(object):
                               obs_metadata=self.obs_metadata,
                               constraint=self.constraint)
 
-
     def _query_and_write(self, filename, chunk_size=None, write_header=True,
                          write_mode='w', obs_metadata=None, constraint=None):
         """
@@ -490,7 +490,6 @@ class InstanceCatalog(object):
         'a' if you want to append to an existing output file (default: 'w')
         """
 
-
         file_handle = open(filename, write_mode)
         if write_header:
             self.write_header(file_handle)
@@ -505,7 +504,6 @@ class InstanceCatalog(object):
 
         file_handle.close()
 
-
     def _write_pre_process(self):
         """
         This function verifies the catalog's required columns, initializes
@@ -516,11 +514,9 @@ class InstanceCatalog(object):
 
         # find the indices of columns that cannot be null
         self._cannotBeNullDexes = []
-        for (i,col) in enumerate(self.iter_column_names()):
+        for (i, col) in enumerate(self.iter_column_names()):
             if col in self.cannot_be_null:
                 self._cannotBeNullDexes.append(i)
-
-
 
     def _write_recarray(self, chunk, file_handle):
         """
@@ -541,8 +537,8 @@ class InstanceCatalog(object):
             for col_name in self.cannot_be_null:
                 if col_name in chunk.dtype.names:
                     str_vec = numpy.char.lower(chunk[col_name].astype('str'))
-                    good_dexes = numpy.where(numpy.logical_and(str_vec!='none',
-                                             numpy.logical_and(str_vec!='nan', str_vec!='null')))
+                    good_dexes = numpy.where(numpy.logical_and(str_vec != 'none',
+                                             numpy.logical_and(str_vec != 'nan', str_vec != 'null')))
                     chunk = chunk[good_dexes]
 
         self._set_current_chunk(chunk)
@@ -595,7 +591,7 @@ class InstanceCatalog(object):
                           if col in self.transformations.keys() else
                           self.column_by_name(col)
                           for col in self.iter_column_names()]
-            chunkColMap = dict([(col, i) for i,col in enumerate(self.iter_column_names())])
+            chunkColMap = dict([(col, i) for i, col in enumerate(self.iter_column_names())])
             yield chunk_cols, chunkColMap
 
     def get_objId(self):
@@ -604,11 +600,12 @@ class InstanceCatalog(object):
     def get_uniqueId(self, nShift=10):
         arr = self.column_by_name(self.refIdCol)
         if len(arr) > 0:
-            return numpy.left_shift(self.column_by_name(self.refIdCol), nShift) + self.db_obj.getObjectTypeId()
+            return numpy.left_shift(self.column_by_name(self.refIdCol), nShift) + \
+                   self.db_obj.getObjectTypeId()
         else:
             return arr
 
-    def _get_class_that_defined_method(self,meth):
+    def _get_class_that_defined_method(self, meth):
         """
         This method will return the name of the class that first defined the
         input method.
@@ -628,9 +625,9 @@ class InstanceCatalog(object):
         Print the origins of the columns in this catalog
         """
 
-        print '\nwhere the columns in ',self.__class__,' come from'
+        print '\nwhere the columns in ', self.__class__, ' come from'
         for column_name in self._column_origins:
-            print column_name,self._column_origins[column_name]
+            print column_name, self._column_origins[column_name]
 
         print '\n'
 

--- a/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
@@ -1,6 +1,6 @@
 """Instance Catalog"""
 import warnings
-import numpy
+import numpy as np
 import inspect
 import re
 import copy
@@ -29,7 +29,7 @@ def is_null(argument):
             return True
         elif argument.strip().lower() == 'none':
             return True
-    elif numpy.isnan(argument):
+    elif np.isnan(argument):
         return True
 
     return False
@@ -80,7 +80,7 @@ class InstanceCatalogMeta(type):
         for default in cls.default_columns:
             setattr(cls, 'default_%s'%(default[0]),
                     lambda self, value=default[1], type=default[2]:
-                    numpy.array([value for i in xrange(len(self._current_chunk))], dtype=type))
+                    np.array([value for i in xrange(len(self._current_chunk))], dtype=type))
 
         # store compound columns and check for collisions
         #
@@ -130,7 +130,7 @@ class _MimicRecordArray(object):
 
     def __getitem__(self, column):
         self.referenced_columns.add(column)
-        return numpy.empty(0)
+        return np.empty(0)
 
     def __len__(self):
         return 0
@@ -534,9 +534,9 @@ class InstanceCatalog(object):
             # rows that have already run afoul of self.cannot_be_null
             for col_name in self.cannot_be_null:
                 if col_name in chunk.dtype.names:
-                    str_vec = numpy.char.lower(chunk[col_name].astype('str'))
-                    good_dexes = numpy.where(numpy.logical_and(str_vec != 'none',
-                                             numpy.logical_and(str_vec != 'nan', str_vec != 'null')))
+                    str_vec = np.char.lower(chunk[col_name].astype('str'))
+                    good_dexes = np.where(np.logical_and(str_vec != 'none',
+                                          np.logical_and(str_vec != 'nan', str_vec != 'null')))
                     chunk = chunk[good_dexes]
 
         self._set_current_chunk(chunk)
@@ -553,7 +553,7 @@ class InstanceCatalog(object):
         # for memory efficiency
         file_handle.writelines(self._template % line
                                for line in zip(*chunk_cols)
-                               if numpy.array([not is_null(line[i]) for i in self._cannotBeNullDexes]).all())
+                               if np.array([not is_null(line[i]) for i in self._cannotBeNullDexes]).all())
                                # the last boolean in this line causes a row not to be printed if it has
                                # a null value in one of the columns that cannot be null; it is ignored
                                # if no columns are specified by cannot_be_null
@@ -596,7 +596,7 @@ class InstanceCatalog(object):
     def get_uniqueId(self, nShift=10):
         arr = self.column_by_name(self.refIdCol)
         if len(arr) > 0:
-            return numpy.left_shift(self.column_by_name(self.refIdCol), nShift) + \
+            return np.left_shift(self.column_by_name(self.refIdCol), nShift) + \
                    self.db_obj.getObjectTypeId()
         else:
             return arr

--- a/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
@@ -558,10 +558,8 @@ class InstanceCatalog(object):
                                # a null value in one of the columns that cannot be null; it is ignored
                                # if no columns are specified by cannot_be_null
 
-
-
     def iter_catalog(self, chunk_size=None):
-        db_required_columns = self.db_required_columns()
+        self.db_required_columns()
 
         query_result = self.db_obj.query_columns(colnames=self._active_columns,
                                                  obs_metadata=self.obs_metadata,
@@ -577,7 +575,7 @@ class InstanceCatalog(object):
                 yield line
 
     def iter_catalog_chunks(self, chunk_size=None):
-        db_required_columns = self.db_required_columns()
+        self.db_required_columns()
 
         query_result = self.db_obj.query_columns(colnames=self._active_columns,
                                                  obs_metadata=self.obs_metadata,

--- a/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
@@ -79,10 +79,8 @@ class InstanceCatalogMeta(type):
         # add methods for default columns
         for default in cls.default_columns:
             setattr(cls, 'default_%s'%(default[0]),
-                lambda self, value=default[1], type=default[2]:\
-                        numpy.array([value for i in
-                                 xrange(len(self._current_chunk))],
-                                 dtype=type))
+                    lambda self, value=default[1], type=default[2]:
+                    numpy.array([value for i in xrange(len(self._current_chunk))], dtype=type))
 
         # store compound columns and check for collisions
         #

--- a/tests/testInstanceCatalog.py
+++ b/tests/testInstanceCatalog.py
@@ -422,7 +422,7 @@ class InstanceCatalogCannotBeNullTest(unittest.TestCase):
         def testCannotBeNull_pre_screen(self):
             """
             Check that writing a catalog with self._pre_screen = True produces
-            the same results as writing one with self._pre_creen = False, except
+            the same results as writing one with self._pre_screen = False, except
             with a smaller self._current_chunk.
             """
 

--- a/tests/testInstanceCatalog.py
+++ b/tests/testInstanceCatalog.py
@@ -128,7 +128,7 @@ class unicodeCannotBeNullCatalog(InstanceCatalog):
 
 class severalCannotBeNullCatalog(InstanceCatalog):
     """
-    This catalog class will not write rows with a null value in the n2 column
+    This catalog class will not write rows with null values in the n2 or n4 columns
     """
     column_outputs = ['id', 'n1', 'n2', 'n3', 'n4', 'n5']
     cannot_be_null = ['n2', 'n4']
@@ -335,7 +335,7 @@ class InstanceCatalogCannotBeNullTest(unittest.TestCase):
         def testCannotBeNull(self):
             """
             Test to make sure that the code for filtering out rows with null values
-            in key rowss works.
+            in key rows works.
             """
 
             # each of these classes flags a different column with a different datatype as cannot_be_null

--- a/tests/testInstanceCatalog.py
+++ b/tests/testInstanceCatalog.py
@@ -350,6 +350,10 @@ class InstanceCatalogCannotBeNullTest(unittest.TestCase):
                                  severalCannotBeNullCatalog]
             dbobj = CatalogDBObject.from_objid('cannotBeNull')
 
+            ct_n2 = 0  # number of rows in floatCannotBeNullCatalog
+            ct_n4 = 0  # number of rows in strCannotBeNullCatalog
+            ct_n2_n4 = 0  # number of rows in severalCannotBeNullCatalog
+
             for catClass in availableCatalogs:
                 cat = catClass(dbobj)
                 fileName = os.path.join(scratch_dir, 'cannotBeNullTestFile.txt')
@@ -378,6 +382,13 @@ class InstanceCatalogCannotBeNullTest(unittest.TestCase):
                                 validLine = False
 
                     if validLine:
+                        if catClass is floatCannotBeNullCatalog:
+                            ct_n2 += 1
+                        elif catClass is strCannotBeNullCatalog:
+                            ct_n4 += 1
+                        elif catClass is severalCannotBeNullCatalog:
+                            ct_n2_n4 += 1
+
                         # if the row in self.baslineOutput should be in the catalog, we now check
                         # that baseline and testData agree on column values (there are some gymnastics
                         # here because you cannot do an == on NaN's
@@ -399,6 +410,11 @@ class InstanceCatalogCannotBeNullTest(unittest.TestCase):
                 msg = '%d >= %d' % (ct_good, ct_total)
                 self.assertLess(ct_good, ct_total, msg=msg)  # make sure that some rows did not make
                                                              # it into the catalog
+
+            # make sure that severalCannotBeNullCatalog weeded out rows that were individually in
+            # floatCannotBeNullCatalog or strCannotBeNullCatalog
+            self.assertGreater(ct_n2, ct_n2_n4)
+            self.assertGreater(ct_n4, ct_n2_n4)
 
             if os.path.exists(fileName):
                 os.unlink(fileName)

--- a/tests/testInstanceCatalog.py
+++ b/tests/testInstanceCatalog.py
@@ -346,7 +346,8 @@ class InstanceCatalogCannotBeNullTest(unittest.TestCase):
             scratch_dir = os.path.join(getPackageDir('sims_catalogs'), 'tests', 'scratchSpace')
 
             # each of these classes flags a different column with a different datatype as cannot_be_null
-            availableCatalogs = [floatCannotBeNullCatalog, strCannotBeNullCatalog, unicodeCannotBeNullCatalog]
+            availableCatalogs = [floatCannotBeNullCatalog, strCannotBeNullCatalog, unicodeCannotBeNullCatalog,
+                                 severalCannotBeNullCatalog]
             dbobj = CatalogDBObject.from_objid('cannotBeNull')
 
             for catClass in availableCatalogs:
@@ -366,14 +367,15 @@ class InstanceCatalogCannotBeNullTest(unittest.TestCase):
                     # first, we must assess whether or not the row we are currently
                     # testing would, in fact, pass the cannot_be_null test
                     validLine = True
-                    if (isinstance(self.baselineOutput[cat.cannot_be_null[0]][i], str) or
-                        isinstance(self.baselineOutput[cat.cannot_be_null[0]][i], unicode)):
+                    for col_name in cat.cannot_be_null:
+                        if (isinstance(self.baselineOutput[col_name][i], str) or
+                            isinstance(self.baselineOutput[col_name][i], unicode)):
 
-                        if self.baselineOutput[cat.cannot_be_null[0]][i].strip().lower() == 'none':
-                            validLine = False
-                    else:
-                        if np.isnan(self.baselineOutput[cat.cannot_be_null[0]][i]):
-                            validLine = False
+                            if self.baselineOutput[col_name][i].strip().lower() == 'none':
+                                validLine = False
+                        else:
+                            if np.isnan(self.baselineOutput[col_name][i]):
+                                validLine = False
 
                     if validLine:
                         # if the row in self.baslineOutput should be in the catalog, we now check

--- a/tests/testInstanceCatalog.py
+++ b/tests/testInstanceCatalog.py
@@ -350,7 +350,8 @@ class InstanceCatalogCannotBeNullTest(unittest.TestCase):
                                   ('n4', (str, 40)), ('n5', (unicode, 40))])
                 testData = np.genfromtxt(fileName, dtype=dtype, delimiter=',')
 
-                j = 0  # a counter to keep track of the rows read in from the catalog
+                ct_good = 0  # a counter to keep track of the rows read in from the catalog
+                ct_total = len(self.baselineOutput)
 
                 for i in range(len(self.baselineOutput)):
 
@@ -375,20 +376,19 @@ class InstanceCatalogCannotBeNullTest(unittest.TestCase):
                             if k < 4:
                                 if not np.isnan(xx):
                                     msg = ('k: %d -- %s %s -- %s' %
-                                           (k, str(xx), str(testData[j][k]), cat.cannot_be_null))
-                                    self.assertAlmostEqual(xx, testData[j][k], 3, msg=msg)
+                                           (k, str(xx), str(testData[ct_good][k]), cat.cannot_be_null))
+                                    self.assertAlmostEqual(xx, testData[ct_good][k], 3, msg=msg)
                                 else:
-                                    np.testing.assert_equal(testData[j][k], np.NaN)
+                                    np.testing.assert_equal(testData[ct_good][k], np.NaN)
                             else:
                                 msg = ('%s (%s) is not %s (%s)' %
-                                       (xx, type(xx), testData[j][k], type(testData[j][k])))
-                                self.assertEqual(xx.strip(), testData[j][k].strip(), msg=msg)
-                        j += 1
+                                       (xx, type(xx), testData[ct_good][k], type(testData[ct_good][k])))
+                                self.assertEqual(xx.strip(), testData[ct_good][k].strip(), msg=msg)
+                        ct_good += 1
 
-                self.assertEqual(i, 99)  # make sure that we tested all of the baseline rows
-                self.assertEqual(j, len(testData))  # make sure that we tested all of the testData rows
-                msg = '%d >= %d' % (j, i)
-                self.assertLess(j, i, msg=msg)  # make sure that some rows did not make it into the catalog
+                self.assertEqual(ct_good, len(testData))  # make sure that we tested all of the testData rows
+                msg = '%d >= %d' % (ct_good, ct_total)
+                self.assertLess(ct_good, ct_total, msg=msg)  # make sure that some rows did not make it into the catalog
 
             if os.path.exists(fileName):
                 os.unlink(fileName)
@@ -415,7 +415,8 @@ class InstanceCatalogCannotBeNullTest(unittest.TestCase):
                                   ('n4', (str, 40)), ('n5', (unicode, 40))])
                 testData = np.genfromtxt(fileName, dtype=dtype, delimiter=',')
 
-                j = 0  # a counter to keep track of the rows read in from the catalog
+                ct_good = 0  # a counter to keep track of the rows read in from the catalog
+                ct_total = len(self.baselineOutput)
 
                 for i in range(len(self.baselineOutput)):
 
@@ -448,21 +449,20 @@ class InstanceCatalogCannotBeNullTest(unittest.TestCase):
                             if k < 4:
                                 if not np.isnan(xx):
                                     msg = ('k: %d -- %s %s -- %s' %
-                                           (k, str(xx), str(testData[j][k]), cat.cannot_be_null))
-                                    self.assertAlmostEqual(xx, testData[j][k], 3, msg=msg)
+                                           (k, str(xx), str(testData[ct_good][k]), cat.cannot_be_null))
+                                    self.assertAlmostEqual(xx, testData[ct_good][k], 3, msg=msg)
                                 else:
-                                    np.testing.assert_equal(testData[j][k], np.NaN)
+                                    np.testing.assert_equal(testData[ct_good][k], np.NaN)
                             else:
                                 msg = ('%s (%s) is not %s (%s)' %
-                                       (xx, type(xx), testData[j][k], type(testData[j][k])))
-                                self.assertEqual(xx.strip(), testData[j][k].strip(), msg=msg)
-                        j += 1
+                                       (xx, type(xx), testData[ct_good][k], type(testData[ct_good][k])))
+                                self.assertEqual(xx.strip(), testData[ct_good][k].strip(), msg=msg)
+                        ct_good += 1
 
-                self.assertEqual(i, 99)  # make sure that we tested all of the baseline rows
-                self.assertEqual(j, len(testData))  # make sure that we tested all of the testData rows
-                msg = '%d >= %d' % (j, i)
-                self.assertLess(j, i, msg=msg)  # make sure that some rows did not make it into the catalog
-                self.assertGreater(j, 0) # makesure that some rows did make it into the catalog
+                self.assertEqual(ct_good, len(testData))  # make sure that we tested all of the testData rows
+                msg = '%d >= %d' % (ct_good, ct_total)
+                self.assertLess(ct_good, ct_total, msg=msg)  # make sure that some rows did not make it into the catalog
+                self.assertGreater(ct_good, 0) # makesure that some rows did make it into the catalog
 
             if os.path.exists(fileName):
                 os.unlink(fileName)

--- a/tests/testInstanceCatalog.py
+++ b/tests/testInstanceCatalog.py
@@ -409,8 +409,16 @@ class InstanceCatalogCannotBeNullTest(unittest.TestCase):
             for catClass in availableCatalogs:
                 cat = catClass(dbobj)
                 cat._pre_screen = True
-                fileName = 'cannotBeNullTestFile.txt'
+                control_cat = catClass(dbobj)
+                fileName = 'cannotBeNullTestFile_prescreen.txt'
+                control_fileName = 'cannotBeNullTestFile_prescreen_control.txt'
                 cat.write_catalog(fileName)
+                control_cat.write_catalog(control_fileName)
+
+                # make sure that pre-screened catalog passed fewer rows into
+                # self._current_chunk than did the non-pre-screened catalog
+                self.assertGreater(control_cat._current_chunk.size, cat._current_chunk.size)
+
                 dtype = np.dtype([('id', int), ('n1', np.float64), ('n2', np.float64), ('n3', np.float64),
                                   ('n4', (str, 40)), ('n5', (unicode, 40))])
                 testData = np.genfromtxt(fileName, dtype=dtype, delimiter=',')
@@ -466,6 +474,8 @@ class InstanceCatalogCannotBeNullTest(unittest.TestCase):
 
             if os.path.exists(fileName):
                 os.unlink(fileName)
+            if os.path.exists(control_fileName):
+                os.unlink(control_fileName)
 
         def testCanBeNull(self):
             """

--- a/tests/testInstanceCatalog.py
+++ b/tests/testInstanceCatalog.py
@@ -395,7 +395,8 @@ class InstanceCatalogCannotBeNullTest(unittest.TestCase):
 
                 self.assertEqual(ct_good, len(testData))  # make sure that we tested all of the testData rows
                 msg = '%d >= %d' % (ct_good, ct_total)
-                self.assertLess(ct_good, ct_total, msg=msg)  # make sure that some rows did not make it into the catalog
+                self.assertLess(ct_good, ct_total, msg=msg)  # make sure that some rows did not make
+                                                             # it into the catalog
 
             if os.path.exists(fileName):
                 os.unlink(fileName)


### PR DESCRIPTION
while testing the Twinkles catalog generation code, I noticed that CompoundInstanceCatalogs were running much slower than straight concatenations of InstanceCatalogs in a way such that t_compound/t_instance scaled with the size of the catalog.  This was because, when made a part of a CompoundInstanceCatalog, InstanceCatalogs were being forced to deal with rows that they didn't have to ordinarily (i.e. galaxies without AGN being passed to the AGN catalog).  This pull request fixes that by allowing InstanceCatalogs to filter the results of database queries directly using their cannot_be_null list of columns.  CompoundInstanceCatalogs are still 20% slower than a concatenation of InstanceCatalogs, but that ratio does not scale with the size of the catalog (before, an InstanceCatalog drawn on a 0.6 degree patch of sky would be 50% slower when generated with CompoundInstanceCatalog).

There is a related pull request on sims_catUtils
