### PR TITLE
Bugfix/sim 2214/sqlalchemy1 1

### DIFF
--- a/python/lsst/sims/catalogs/db/utils.py
+++ b/python/lsst/sims/catalogs/db/utils.py
@@ -1,11 +1,12 @@
 from __future__ import with_statement
 from collections import OrderedDict
 import warnings
-import numpy
+import numpy as np
 from StringIO import StringIO
 from sqlalchemy import (types as satypes, Column, Table, Index, 
     create_engine, MetaData)
 import string, random
+
 #from http://stackoverflow.com/questions/2257441/python-random-string-generation-with-upper-case-letters-and-digits
 def id_generator(size=8, chars=string.ascii_lowercase):
     return ''.join(random.choice(chars) for x in range(size))
@@ -23,7 +24,7 @@ def guessDtype(dataPath, numGuess, delimiter, **kwargs):
         while cnt < numGuess:
             teststr += fh.readline()
             cnt += 1
-    dataArr = numpy.genfromtxt(StringIO(teststr), dtype=None, names=True, delimiter=delimiter, **kwargs)
+    dataArr = np.genfromtxt(StringIO(teststr), dtype=None, names=True, delimiter=delimiter, **kwargs)
     return dataArr.dtype
 
 def buildTypeMap():
@@ -33,7 +34,7 @@ def buildTypeMap():
         if hasattr(obj, 'dtype'):
             try:
                 npn = obj(0)
-                nat = numpy.asscalar(npn)
+                nat = np.asscalar(npn)
                 npTypeMap[npn.dtype.char] = type(nat)
             except:
                 pass
@@ -86,17 +87,17 @@ def loadTable(datapath, datatable, delimiter, dtype, engine, indexCols=[], skipL
             cnt += 1
             if cnt%chunkSize == 0:
                 print "Loading chunk #%i"%(int(cnt/chunkSize))
-                dataArr = numpy.genfromtxt(StringIO(tmpstr), dtype=dtype, delimiter=delimiter, **kwargs)
-                engine.execute(datatable.insert(), [dict((name, numpy.asscalar(l[name])) for name in l.dtype.names) for l in dataArr])
+                dataArr = np.genfromtxt(StringIO(tmpstr), dtype=dtype, delimiter=delimiter, **kwargs)
+                engine.execute(datatable.insert(), [dict((name, np.asscalar(l[name])) for name in l.dtype.names) for l in dataArr])
                 tmpstr = ''
         #Clean up the last chunk
         if len(tmpstr) > 0:
-            dataArr = numpy.genfromtxt(StringIO(tmpstr), dtype=dtype, delimiter=delimiter, **kwargs)
+            dataArr = np.genfromtxt(StringIO(tmpstr), dtype=dtype, delimiter=delimiter, **kwargs)
             try:
-                engine.execute(datatable.insert(), [dict((name, numpy.asscalar(l[name])) for name in l.dtype.names) for l in dataArr])
+                engine.execute(datatable.insert(), [dict((name, np.asscalar(l[name])) for name in l.dtype.names) for l in dataArr])
             # If the file only has one line, the result of genfromtxt is a 0-d array, so cannot be iterated
             except TypeError:
-                engine.execute(datatable.insert(), [dict((name, numpy.asscalar(dataArr[name])) for name in dataArr.dtype.names),])
+                engine.execute(datatable.insert(), [dict((name, np.asscalar(dataArr[name])) for name in dataArr.dtype.names),])
 
     for col in indexCols:
         if hasattr(col, "__iter__"):

--- a/python/lsst/sims/catalogs/db/utils.py
+++ b/python/lsst/sims/catalogs/db/utils.py
@@ -60,7 +60,7 @@ def buildTypeMap():
                 pass
     return npTypeMap
 
-def createSQLTable(dtype, tableid, idCol, metadata, customTypeMap={}, defaultPrecision=16, defaultScale=6):
+def createSQLTable(dtype, tableid, idCol, metadata):
     sqlColumns = []
     for itype in range(len(dtype)):
         sqlType = np_to_sql_type(dtype[itype])

--- a/python/lsst/sims/catalogs/db/utils.py
+++ b/python/lsst/sims/catalogs/db/utils.py
@@ -61,6 +61,20 @@ def buildTypeMap():
     return npTypeMap
 
 def createSQLTable(dtype, tableid, idCol, metadata):
+    """
+    create a sqlalchemy Table object.
+
+    Parameters
+    ----------
+    dtype is a numpy dtype describing the columns in the table
+    tableid is the name of the table to be created
+    idCol is the column on which to construct the Table's primary key
+    metadata is the sqlalchemy MetaData object associated with the database connection
+
+    Returns
+    -------
+    A sqlalchemy Table object with the columns specified by dtype
+    """
     sqlColumns = []
     for itype in range(len(dtype)):
         sqlType = np_to_sql_type(dtype[itype])

--- a/python/lsst/sims/catalogs/db/utils.py
+++ b/python/lsst/sims/catalogs/db/utils.py
@@ -47,18 +47,6 @@ def guessDtype(dataPath, numGuess, delimiter, **kwargs):
     dataArr = np.genfromtxt(StringIO(teststr), dtype=None, names=True, delimiter=delimiter, **kwargs)
     return dataArr.dtype
 
-def buildTypeMap():
-    npTypeMap = {}
-    for name in dir(numpy):
-        obj = getattr(numpy, name)
-        if hasattr(obj, 'dtype'):
-            try:
-                npn = obj(0)
-                nat = np.asscalar(npn)
-                npTypeMap[npn.dtype.char] = type(nat)
-            except:
-                pass
-    return npTypeMap
 
 def createSQLTable(dtype, tableid, idCol, metadata):
     """

--- a/tests/testFileDBObject.py
+++ b/tests/testFileDBObject.py
@@ -1,0 +1,72 @@
+from __future__ import with_statement
+import unittest
+import string
+import os
+import numpy as np
+import lsst.utils.tests
+from lsst.utils import getPackageDir
+from lsst.sims.catalogs.db import fileDBObject
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+class FileDBObjectTestCase(unittest.TestCase):
+    """
+    This class will test that fileDBObject can correctly ingest a database,
+    preserving all of the data it was given.  This is it's own test because
+    a lot of other unit tests depend on fileDBObject to create data to test
+    against.
+    """
+
+    def setUp(self):
+        self.scratch_dir = os.path.join(getPackageDir("sims_catalogs"),
+                                        "tests", "scratchSpace")
+
+    def test_ingest(self):
+        """
+        Test that fileDBObject correctly ingests a text file containing
+        multiple data types.
+        """
+        txt_file_name = os.path.join(self.scratch_dir,
+                                     "filedbojb_ingest_test.txt")
+
+        rng = np.random.RandomState(8821)
+        n_rows = 34
+        n_letters = 72
+        f_list = rng.random_sample(n_rows)
+        i_list = rng.randint(0, 2**50, n_rows)
+        word_dex_list = rng.randint(0, len(string.letters)-1, (n_rows, n_letters))
+        word_list = []
+        with open(txt_file_name, 'w') as output_file:
+            output_file.write("# a header\n")
+            for ix, (ff, ii, ww) in enumerate(zip(f_list, i_list, word_dex_list)):
+                word = ''
+                for wwdex in ww:
+                    word += string.letters[wwdex]
+                word_list.append(word)
+                self.assertEqual(len(word), n_letters)
+                output_file.write('%d %.13f %ld %s\n' % (ix, ff, ii, word))
+
+        dtype = np.dtype([('id', int), ('float', float), ('int', int), ('word', str, n_letters)])
+        db = fileDBObject(txt_file_name, runtable='test', dtype=dtype, idColKey='id')
+        results = db.execute_arbitrary('SELECT * from test')
+        self.assertEqual(len(results), n_rows)
+        for row in results:
+            i_row = row[0]
+            self.assertAlmostEqual(f_list[i_row], row[1], 13)
+            self.assertEqual(i_list[i_row], row[2])
+            self.assertEqual(word_list[i_row], row[3])
+
+        if os.path.exists(txt_file_name):
+            os.unlink(txt_file_name)
+
+
+class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
We were using a private sqlalchemy dict to map from numpy types to SQL types when loading a text file with `fileDBObject`.  That private member went away somewhere between sqlalchemy versions 1.0 and 1.1.  This pull request adds our own custom method to map between the two datatypes, so `sims_catalogs` can now build against sqlalchemy version 1.1