### PR TITLE
Feature/sim 2112/write end2end scripts

### DIFF
--- a/python/lsst/sims/catalogs/db/CompoundCatalogDBObject.py
+++ b/python/lsst/sims/catalogs/db/CompoundCatalogDBObject.py
@@ -91,7 +91,8 @@ class CompoundCatalogDBObject(CatalogDBObject):
         column_names = []
         self.columns = []
         for dbo, dbName in zip(self._dbObjectClassList, self._nameList):
-            for row in dbo.columns:
+            db_inst = dbo()
+            for row in db_inst.columns:
                 new_row = [ww for ww in row]
                 new_row[0] = str('%s_%s' % (dbName, row[0]))
                 if new_row[1] is None:

--- a/python/lsst/sims/catalogs/db/dbConnection.py
+++ b/python/lsst/sims/catalogs/db/dbConnection.py
@@ -19,7 +19,8 @@ from lsst.daf.persistence import DbAuth
 #TODO: test for cdecimal and use it if it exists.
 import decimal
 
-__all__ = ["ChunkIterator", "DBObject", "CatalogDBObject", "fileDBObject"]
+__all__ = ["ChunkIterator", "DBObject", "CatalogDBObject", "fileDBObject",
+           "_get_connection"]
 
 def valueOfPi():
     """

--- a/python/lsst/sims/catalogs/db/dbConnection.py
+++ b/python/lsst/sims/catalogs/db/dbConnection.py
@@ -193,11 +193,11 @@ class DBConnection(object):
 
 
     def __eq__(self, other):
-        return (self._database is other._database) and \
-               (self._driver is other._driver) and \
-               (self._host is other._host) and \
-               (self._port is other._port) and \
-               (self._verbose is other._verbose)
+        return (str(self._database) == str(other._database)) and \
+               (str(self._driver) == str(other._driver)) and \
+               (str(self._host) == str(other._host)) and \
+               (str(self._port) == str(other._port)) and \
+               (str(self._verbose) == str(other._verbose))
 
 
     @property

--- a/python/lsst/sims/catalogs/db/dbConnection.py
+++ b/python/lsst/sims/catalogs/db/dbConnection.py
@@ -20,7 +20,7 @@ from lsst.daf.persistence import DbAuth
 import decimal
 
 __all__ = ["ChunkIterator", "DBObject", "CatalogDBObject", "fileDBObject",
-           "_get_connection"]
+           "_get_connection", "_close_all_connections"]
 
 def valueOfPi():
     """
@@ -235,6 +235,17 @@ class DBConnection(object):
 
 
 _connection_cache = []
+
+
+def _close_all_connections():
+    """
+    Close all of the database connections in the _conneciton_cache.
+    This is mostly needed to clean up after ourselves in unit tests.
+    """
+    global _connection_cache
+    for conn in _connection_cache:
+        del conn
+    _connection_cache = []
 
 
 def _get_connection(database, driver, host, port):

--- a/python/lsst/sims/catalogs/db/dbConnection.py
+++ b/python/lsst/sims/catalogs/db/dbConnection.py
@@ -561,8 +561,15 @@ class CatalogDBObject(DBObject):
         if self.idColKey is None:
             self.idColKey = self.getIdColKey()
         if (self.objid is None) or (self.tableid is None) or (self.idColKey is None):
-            raise ValueError("CatalogDBObject must be subclassed, and "
-                             "define objid, tableid and idColKey.")
+            msg = ("CatalogDBObject must be subclassed, and "
+                   "define objid, tableid and idColKey.  You are missing: ")
+            if self.objid is None:
+                msg += "objid, "
+            if self.tableid is None:
+                msg += "tableid, "
+            if self.idColKey is None:
+                msg += "idColKey"
+            raise ValueError(msg)
 
         if (self.objectTypeId is None) and verbose:
             warnings.warn("objectTypeId has not "

--- a/python/lsst/sims/catalogs/db/dbConnection.py
+++ b/python/lsst/sims/catalogs/db/dbConnection.py
@@ -196,8 +196,7 @@ class DBConnection(object):
         return (str(self._database) == str(other._database)) and \
                (str(self._driver) == str(other._driver)) and \
                (str(self._host) == str(other._host)) and \
-               (str(self._port) == str(other._port)) and \
-               (str(self._verbose) == str(other._verbose))
+               (str(self._port) == str(other._port))
 
 
     @property

--- a/python/lsst/sims/catalogs/db/dbConnection.py
+++ b/python/lsst/sims/catalogs/db/dbConnection.py
@@ -301,10 +301,10 @@ class DBObject(object):
 
         if hasattr(self, '_connection_cache'):
             for conn in self._connection_cache:
-                if conn.database is database:
-                    if conn.driver is driver:
-                        if conn.host is host:
-                            if conn.port is port:
+                if str(conn.database) == str(database):
+                    if str(conn.driver) == str(driver):
+                        if str(conn.host) == str(host):
+                            if str(conn.port) == str(port):
                                 return conn
 
         conn = DBConnection(database=database, driver=driver, host=host, port=port)

--- a/python/lsst/sims/catalogs/db/dbConnection.py
+++ b/python/lsst/sims/catalogs/db/dbConnection.py
@@ -255,10 +255,10 @@ def _get_connection(database, driver, host, port):
     global _connection_cache
 
     for conn in _connection_cache:
-        if conn.database == database:
-            if conn.driver == driver:
-                if conn.host == host:
-                    if conn.port == port:
+        if conn.database is database:
+            if conn.driver is driver:
+                if conn.host is host:
+                    if conn.port is port:
                         return conn
 
     conn = DBConnection(database=database, driver=driver, host=host, port=port)

--- a/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
@@ -564,6 +564,8 @@ class InstanceCatalog(object):
                 good_dexes = np.where(np.logical_and(filter_vals != 'none',
                                       np.logical_and(filter_vals  != 'nan', filter_vals != 'null')))
 
+                final_dexes = final_dexes[good_dexes]
+
                 if len(good_dexes[0]) < len(chunk):
                     self._update_current_chunk(good_dexes)
 

--- a/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
@@ -133,6 +133,8 @@ class InstanceCatalog(object):
     specFileMap = defaultSpecMap
     default_columns = []
     cannot_be_null = None  # will be a list of columns which, if null, cause a row not to be printed by write_catalog()
+                           # Note: these columns will be filtered on even if they are not included in column_outputs
+
     default_formats = {'S': '%s', 'f': '%.4f', 'i': '%i'}
     override_formats = {}
     transformations = {}
@@ -194,6 +196,8 @@ class InstanceCatalog(object):
         which cannot have the values Null, None, or NaN.  Rows running afoul
         of this criterion will not be written by the write_catalog() method
         (though they may appear in the iterator returned by iter_catalog()).
+        Note: these columns will be filtered on, even if they do not appear in
+        column_outputs.
 
         @param [in] constraint is an optional SQL constraint to be applied to the
         database query

--- a/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
@@ -131,7 +131,7 @@ class InstanceCatalog(object):
     column_outputs = None
     specFileMap = defaultSpecMap
     default_columns = []
-    cannot_be_null = []  # a list of columns which, if null, cause a row not to be printed by write_catalog()
+    cannot_be_null = None  # will be a list of columns which, if null, cause a row not to be printed by write_catalog()
     default_formats = {'S': '%s', 'f': '%.4f', 'i': '%i'}
     override_formats = {}
     transformations = {}
@@ -498,7 +498,7 @@ class InstanceCatalog(object):
         the catalog is being written.
         """
 
-        if self._pre_screen:
+        if self._pre_screen and self.cannot_be_null is not None:
             # go through the database query results and remove all of those
             # rows that have already run afoul of self.cannot_be_null
             for col_name in self.cannot_be_null:
@@ -512,7 +512,7 @@ class InstanceCatalog(object):
 
         # If some columns are specified as cannot_be_null, loop over those columns,
         # removing rows that run afoul of that criterion from the chunk.
-        if len(self.cannot_be_null) > 0:
+        if self.cannot_be_null is not None:
             for filter_col in self.cannot_be_null:
                 try:
                     filter_vals = np.char.lower(self.column_by_name(filter_col).astype('str'))

--- a/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
@@ -305,6 +305,13 @@ class InstanceCatalog(object):
             # just call the column: this will log queries to the database.
             self.column_by_name(col_name)
 
+        # now do the same thing for columns specified in cannot_be_null
+        # (in case the catalog is filtered on columns that are not meant
+        # to be written to the catalog)
+        if self.cannot_be_null is not None:
+            for col_name in self.cannot_be_null:
+                self.column_by_name(col_name)
+
         db_required_columns = list(self._current_chunk.referenced_columns)
 
         default_columns_set = set(el[0] for el in self.default_columns)

--- a/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
@@ -515,11 +515,7 @@ class InstanceCatalog(object):
         # removing rows that run afoul of that criterion from the chunk.
         if self.cannot_be_null is not None:
             for filter_col in self.cannot_be_null:
-                try:
-                    filter_vals = np.char.lower(self.column_by_name(filter_col).astype('str'))
-                except:
-                    # apparently, the column does not exist in this catalog
-                    continue
+                filter_vals = np.char.lower(self.column_by_name(filter_col).astype('str'))
 
                 good_dexes = np.where(np.logical_and(filter_vals != 'none',
                                       np.logical_and(filter_vals  != 'nan', filter_vals != 'null')))

--- a/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
@@ -239,6 +239,13 @@ class InstanceCatalog(object):
                     if col not in self._column_outputs:
                         self._column_outputs.append(col)
 
+        # Because cannot_be_null can both be declared at class definition
+        # and at instantiation, we need to be able to combine the two inputs
+        # into something the InstanceCatalog will actually use to filter
+        # rows.  self._cannot_be_null is a member variable that contains
+        # the contents both of self.cannot_be_null (set at class definition)
+        # and the cannot_be_null kwarg passed to __init__().  self._cannot_be_null
+        # is what the catalog actually uses in self._filter_chunk
         self._cannot_be_null = None
         if self.cannot_be_null is not None:
             self._cannot_be_null = copy.deepcopy(self.cannot_be_null)

--- a/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
@@ -545,6 +545,9 @@ class InstanceCatalog(object):
 
                     self._set_current_chunk(chunk, column_cache=new_cache)
 
+        if len(self._current_chunk) is 0:
+            return
+
         chunk_cols = [self.transformations[col](self.column_by_name(col))
                       if col in self.transformations.keys() else
                       self.column_by_name(col)

--- a/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
+++ b/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
@@ -16,7 +16,7 @@ def parallelCatalogWriter(catalog_dict, chunk_size=None, constraint=None,
     Parameters
     ----------
     catalog_dict is a dict keyed on the names of the files to be written.
-    The values are the IntanceCatalogs to be written (note: these are full
+    The values are the InstanceCatalogs to be written (note: these are full
     instantiations of InstanceCatalogs, not just InstanceCatalog classes
     as with the CompoundInstanceCatalog)
 

--- a/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
+++ b/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
@@ -4,9 +4,7 @@ import copy
 __all__ = ["parallelCatalogWriter"]
 
 
-def parallelCatalogWriter(catalog_dict,
-                          obs_metadata=None, constraint=None,
-                          cannot_be_null=None, chunk_size=None,
+def parallelCatalogWriter(catalog_dict, chunk_size=None, constraint=None,
                           write_mode='w', write_header=True):
     """
     This method will take several InstanceCatalog classes that are meant
@@ -22,13 +20,8 @@ def parallelCatalogWriter(catalog_dict,
     instantiations of InstanceCatalogs, not just InstanceCatalog classes
     as with the CompoundInstanceCatalog)
 
-    obs_metadata is an ObservationMetaData describing the field of view
-
-    constraint is an optional SQL constraint to be applied to the database query
-
-    cannot_be_null as an optional list of catalog columns that cannot be null
-    in any of the catalogs (note: catalogs will only contain rows which pass this
-    test for all catalogs).
+    constraint is an optional SQL constraint to be applied to the database query.
+    Note: constraints applied to individual catalogs will be ignored.
 
     chunk_size is an int which optionally specifies the number of rows to be
     returned from db_obj at a time
@@ -90,7 +83,7 @@ def parallelCatalogWriter(catalog_dict,
                     active_columns.append(col_name)
 
     query_result = ref_cat.db_obj.query_columns(colnames=active_columns,
-                                                obs_metadata=obs_metadata,
+                                                obs_metadata=ref_cat.obs_metadata,
                                                 constraint=constraint,
                                                 chunk_size=chunk_size)
 

--- a/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
+++ b/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
@@ -1,4 +1,5 @@
 import copy
+import time
 
 
 __all__ = ["parallelCatalogWriter"]
@@ -98,6 +99,7 @@ def parallelCatalogWriter(catalog_dict, chunk_size=None, constraint=None,
             catalog_dict[file_name].write_header(file_handle)
 
     for master_chunk in query_result:
+        t_start = time.time()
         chunk = master_chunk
 
         for i_file, file_name in enumerate(list_of_file_names):
@@ -113,6 +115,8 @@ def parallelCatalogWriter(catalog_dict, chunk_size=None, constraint=None,
 
         for file_name in catalog_dict:
             catalog_dict[file_name]._write_current_chunk(file_handle_dict[file_name])
+
+        print '    did chunk in ',time.time()-t_start
 
     for file_name in file_handle_dict:
         file_handle_dict[file_name].close()

--- a/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
+++ b/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
@@ -1,5 +1,4 @@
 import copy
-import time
 
 
 __all__ = ["parallelCatalogWriter"]
@@ -97,7 +96,6 @@ def parallelCatalogWriter(catalog_dict, chunk_size=None, constraint=None,
         local_write_mode = 'a'
 
     for master_chunk in query_result:
-        t_start = time.time()
 
         for i_file, file_name in enumerate(list_of_file_names):
             chunk = master_chunk
@@ -110,4 +108,3 @@ def parallelCatalogWriter(catalog_dict, chunk_size=None, constraint=None,
                 catalog_dict[file_name]._write_current_chunk(file_handle)
 
         local_write_mode = 'a'
-        print '    did chunk in ',time.time()-t_start

--- a/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
+++ b/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
@@ -111,7 +111,6 @@ def parallelCatalogWriter(catalog_dict, chunk_size=None, constraint=None,
                 local_write_mode = write_mode
 
             with open(file_name, local_write_mode) as file_handle:
-                print 'writing to ',file_name
                 catalog_dict[file_name]._write_current_chunk(file_handle)
 
         first_chunk = False

--- a/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
+++ b/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
@@ -66,7 +66,7 @@ def parallelCatalogWriter(catalog_dict, chunk_size=None, constraint=None,
                        + 'port: %s != %s\n' % (cat.db_obj.connection.port, ref_cat.db_obj.connection.port)
                        + 'driver: %s != %s\n' % (cat.db_obj.connection.driver, ref_cat.db_obj.connection.driver)
                        + 'table: %s != %s\n' % (cat.db_obj.tableid, ref_cat.db_obj.tableid)
-                       + 'objid: %s !- %s\n' % (cat.db_obj.objid, ref_cat.db_obj.objid))
+                       + 'objid: %s != %s\n' % (cat.db_obj.objid, ref_cat.db_obj.objid))
 
                 raise RuntimeError(msg)
 

--- a/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
+++ b/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
@@ -61,12 +61,12 @@ def parallelCatalogWriter(catalog_dict, chunk_size=None, constraint=None,
             except:
                 msg = ('Cannot build these catalogs in parallel. '
                        'The two databases are different.  Connection info is:\n'
-                       'database: %s != %s\n' % (cat.db_obj.connection.database, ref_cat.db_obj.database)
-                       + 'host: %s != %s\n' % (cat.db_obj.connection.host, ref_cat.db_obj.connection.host)
-                       + 'port: %s != %s\n' % (cat.db_obj.connection.port, ref_cat.db_obj.connection.port)
-                       + 'driver: %s != %s\n' % (cat.db_obj.connection.driver, ref_cat.db_obj.connection.driver)
-                       + 'table: %s != %s\n' % (cat.db_obj.tableid, ref_cat.db_obj.tableid)
-                       + 'objid: %s != %s\n' % (cat.db_obj.objid, ref_cat.db_obj.objid))
+                       'database: %s vs. %s\n' % (cat.db_obj.connection.database, ref_cat.db_obj.database)
+                       + 'host: %s vs. %s\n' % (cat.db_obj.connection.host, ref_cat.db_obj.connection.host)
+                       + 'port: %s vs. %s\n' % (cat.db_obj.connection.port, ref_cat.db_obj.connection.port)
+                       + 'driver: %s vs. %s\n' % (cat.db_obj.connection.driver, ref_cat.db_obj.connection.driver)
+                       + 'table: %s vs. %s\n' % (cat.db_obj.tableid, ref_cat.db_obj.tableid)
+                       + 'objid: %s vs. %s\n' % (cat.db_obj.objid, ref_cat.db_obj.objid))
 
                 raise RuntimeError(msg)
 

--- a/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
+++ b/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
@@ -16,9 +16,9 @@ def parallelCatalogWriter(catalog_dict, chunk_size=None, constraint=None,
     Parameters
     ----------
     catalog_dict is a dict keyed on the names of the files to be written.
-    The values are the InstanceCatalogs to be written (note: these are full
+    The values are the InstanceCatalogs to be written.  These are full
     instantiations of InstanceCatalogs, not just InstanceCatalog classes
-    as with the CompoundInstanceCatalog)
+    as with the CompoundInstanceCatalog.  They cannot be CompoundInstanceCatalogs
 
     constraint is an optional SQL constraint to be applied to the database query.
     Note: constraints applied to individual catalogs will be ignored.

--- a/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
+++ b/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
@@ -111,6 +111,7 @@ def parallelCatalogWriter(catalog_dict, chunk_size=None, constraint=None,
                 local_write_mode = write_mode
 
             with open(file_name, local_write_mode) as file_handle:
+                print 'writing to ',file_name
                 catalog_dict[file_name]._write_current_chunk(file_handle)
 
         first_chunk = False

--- a/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
+++ b/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
@@ -1,0 +1,99 @@
+import copy
+
+
+__all__ = ["parallelCatalogWriter"]
+
+
+def parallelCatalogWriter(catalog_class_dict, db_obj,
+                          obs_metadata=None, constraint=None,
+                          cannot_be_null=None, chunk_size=None,
+                          write_mode='w'):
+    """
+    This method will take several InstanceCatalog classes that are meant
+    to be based on the same CatalogDBObject and write them out in parallel
+    from a single database query.  The imagined use-case is simultaneously
+    writing out a PhoSim InstanceCatalog as well as the truth catalog with
+    the pre-calculated positions and magnitudes of the sources.
+
+    Parameters
+    ----------
+    catalog_class_dict is a dict keyed on the names of the files to be written.
+    The values are the IntanceCatalog classes to be written (note: the classes,
+    not instantiations of those classes; this method will instantiate them
+    for you)
+
+    db_obj is the CatalogDBObject on which to base the catalogs (the actual
+    instantiation; not just the class)
+
+    obs_metadata is an ObservationMetaData describing the field of view
+
+    constraint is an optional SQL constraint to be applied to the database query
+
+    cannot_be_null as an optional list of catalog columns that cannot be null
+    in any of the catalogs (note: catalogs will only contain rows which pass this
+    test for all catalogs).
+
+    chunk_size is an int which optionally specifies the number of rows to be
+    returned from db_obj at a time
+
+    write_mode is either 'w' (write) or 'a' (append), determining whether or
+    not the writer will overwrite existing catalog files (assuming they exist)
+
+    Output
+    ------
+    This method does not return anything, it just writes the files that are the
+    keys of catalog_class_dict
+    """
+
+    catalog_dict = {}
+    for file_name in catalog_class_dict:
+        cat_class = catalog_class_dict[file_name]
+        cat = cat_class(db_obj, obs_metadata=obs_metadata,
+                        constraint=constraint,
+                        cannot_be_null=cannot_be_null)
+
+        cat._write_pre_process()
+        catalog_dict[file_name] = cat
+
+    active_columns = None
+    for file_name in catalog_dict:
+        cat = catalog_dict[file_name]
+        if active_columns is None:
+            active_columns = copy.deepcopy(cat._active_columns)
+        else:
+            for col_name in cat._active_columns:
+                if col_name not in active_columns:
+                    active_columns.append(col_name)
+
+    query_result = db_obj.query_columns(colnames=active_columns,
+                                        obs_metadata=obs_metadata,
+                                        constraint=constraint,
+                                        chunk_size=chunk_size)
+
+    file_handle_dict = {}
+    for file_name in catalog_class_dict:
+        file_handle = open(file_name, write_mode)
+        file_handle_dict[file_name] = file_handle
+        catalog_dict[file_name].write_header(file_handle)
+
+    list_of_file_names = catalog_dict.keys()
+
+    for master_chunk in query_result:
+        chunk = master_chunk
+
+        for i_file, file_name in enumerate(list_of_file_names):
+            cat = catalog_dict[file_name]
+            good_dexes = cat._filter_chunk(chunk)
+
+            if len(good_dexes) < len(chunk):
+                for i_old in range(i_file):
+                    old_cat = catalog_dict[list_of_file_names[i_old]]
+                    old_cat._update_current_chunk(good_dexes)
+
+                chunk = chunk[good_dexes]
+
+        for file_name in catalog_class_dict:
+            catalog_dict[file_name]._write_current_chunk(file_handle_dict[file_name])
+
+    for file_name in file_handle_dict:
+        file_handle_dict[file_name].close()

--- a/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
+++ b/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
@@ -51,6 +51,14 @@ def parallelCatalogWriter(catalog_dict,
         if ix>0:
             cat = catalog_dict[file_name]
             try:
+                assert cat.obs_metadata == ref_cat.obs_metadata
+            except:
+                print cat.obs_metadata
+                print ref_cat.obs_metadata
+                raise RuntimeError('Catalogs passed to parallelCatalogWriter have different '
+                                   'ObservationMetaData.  I do not know how to deal with that.')
+
+            try:
                 assert cat.db_obj.connection.database is ref_cat.db_obj.connection.database
                 assert cat.db_obj.connection.host is ref_cat.db_obj.connection.host
                 assert cat.db_obj.connection.port is ref_cat.db_obj.connection.port

--- a/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
+++ b/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
@@ -89,12 +89,12 @@ def parallelCatalogWriter(catalog_dict, chunk_size=None, constraint=None,
                                                 obs_metadata=ref_cat.obs_metadata,
                                                 constraint=constraint,
                                                 chunk_size=chunk_size)
+    local_write_mode = write_mode
     if write_header:
         for file_name in catalog_dict:
-            with open(file_name, write_mode) as file_handle:
+            with open(file_name, local_write_mode) as file_handle:
                 catalog_dict[file_name].write_header(file_handle)
-
-    first_chunk = True
+        local_write_mode = 'a'
 
     for master_chunk in query_result:
         t_start = time.time()
@@ -106,12 +106,8 @@ def parallelCatalogWriter(catalog_dict, chunk_size=None, constraint=None,
             if len(good_dexes) < len(chunk):
                 chunk = chunk[good_dexes]
 
-            write_mode = 'a'
-            if first_chunk:
-                local_write_mode = write_mode
-
             with open(file_name, local_write_mode) as file_handle:
                 catalog_dict[file_name]._write_current_chunk(file_handle)
 
-        first_chunk = False
+        local_write_mode = 'a'
         print '    did chunk in ',time.time()-t_start

--- a/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
+++ b/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
@@ -65,7 +65,8 @@ def parallelCatalogWriter(catalog_dict, chunk_size=None, constraint=None,
                        + 'host: %s != %s\n' % (cat.db_obj.connection.host, ref_cat.db_obj.connection.host)
                        + 'port: %s != %s\n' % (cat.db_obj.connection.port, ref_cat.db_obj.connection.port)
                        + 'driver: %s != %s\n' % (cat.db_obj.connection.driver, ref_cat.db_obj.connection.driver)
-                       + 'table: %s != %s\n' % (cat.db_obj.tableid, ref_cat.db_obj.tableid))
+                       + 'table: %s != %s\n' % (cat.db_obj.tableid, ref_cat.db_obj.tableid)
+                       + 'objid: %s !- %s\n' % (cat.db_obj.objid, ref_cat.db_obj.objid))
 
                 raise RuntimeError(msg)
 

--- a/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
+++ b/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
@@ -7,7 +7,7 @@ __all__ = ["parallelCatalogWriter"]
 def parallelCatalogWriter(catalog_class_dict, db_obj,
                           obs_metadata=None, constraint=None,
                           cannot_be_null=None, chunk_size=None,
-                          write_mode='w'):
+                          write_mode='w', write_header=True):
     """
     This method will take several InstanceCatalog classes that are meant
     to be based on the same CatalogDBObject and write them out in parallel
@@ -38,6 +38,9 @@ def parallelCatalogWriter(catalog_class_dict, db_obj,
 
     write_mode is either 'w' (write) or 'a' (append), determining whether or
     not the writer will overwrite existing catalog files (assuming they exist)
+
+    write_header is a boolean that controls whether or not to write the header
+    in the catalogs.
 
     Output
     ------
@@ -74,7 +77,9 @@ def parallelCatalogWriter(catalog_class_dict, db_obj,
     for file_name in catalog_class_dict:
         file_handle = open(file_name, write_mode)
         file_handle_dict[file_name] = file_handle
-        catalog_dict[file_name].write_header(file_handle)
+
+        if write_header:
+            catalog_dict[file_name].write_header(file_handle)
 
     list_of_file_names = catalog_dict.keys()
 

--- a/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
+++ b/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
@@ -57,6 +57,7 @@ def parallelCatalogWriter(catalog_dict, chunk_size=None, constraint=None,
                 assert cat.db_obj.connection.port is ref_cat.db_obj.connection.port
                 assert cat.db_obj.connection.driver is ref_cat.db_obj.connection.driver
                 assert cat.db_obj.tableid is ref_cat.db_obj.tableid
+                assert cat.db_obj.objid is ref_cat.db_obj.objid
             except:
                 msg = ('Cannot build these catalogs in parallel. '
                        'The two databases are different.  Connection info is:\n'

--- a/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
+++ b/python/lsst/sims/catalogs/definitions/ParallelCatalogWriter.py
@@ -52,12 +52,7 @@ def parallelCatalogWriter(catalog_dict, chunk_size=None, constraint=None,
                                    'ObservationMetaData.  I do not know how to deal with that.')
 
             try:
-                assert cat.db_obj.connection.database is ref_cat.db_obj.connection.database
-                assert cat.db_obj.connection.host is ref_cat.db_obj.connection.host
-                assert cat.db_obj.connection.port is ref_cat.db_obj.connection.port
-                assert cat.db_obj.connection.driver is ref_cat.db_obj.connection.driver
-                assert cat.db_obj.tableid is ref_cat.db_obj.tableid
-                assert cat.db_obj.objid is ref_cat.db_obj.objid
+                assert cat.db_obj.connection == ref_cat.db_obj.connection
             except:
                 msg = ('Cannot build these catalogs in parallel. '
                        'The two databases are different.  Connection info is:\n'

--- a/python/lsst/sims/catalogs/definitions/__init__.py
+++ b/python/lsst/sims/catalogs/definitions/__init__.py
@@ -1,2 +1,3 @@
 from .InstanceCatalog import *
 from .CompoundInstanceCatalog import *
+from .ParallelCatalogWriter import *

--- a/tests/testConnectionPassing.py
+++ b/tests/testConnectionPassing.py
@@ -150,6 +150,9 @@ class ConnectionPassingTest(unittest.TestCase):
 
         stars = starDBObj()
         galaxies = galDBObj(connection=stars.connection)
+
+        self.assertEqual(stars.connection, galaxies.connection)
+
         starCat = starCatalog(stars)
         galCat = galCatalog(galaxies)
         starCat.write_catalog(catName, chunk_size=5)

--- a/tests/testFilteringCatalogs.py
+++ b/tests/testFilteringCatalogs.py
@@ -329,6 +329,9 @@ class InstanceCatalogTestCase(unittest.TestCase):
                 self.assertLess(ii+3, 7)
                 self.assertEqual(line, '%d, %d\n' % (ii, ii+1))
 
+        if os.path.exists(cat_name):
+            os.unlink(cat_name)
+
 
 class CompoundInstanceCatalogTestCase(unittest.TestCase):
     """

--- a/tests/testFilteringCatalogs.py
+++ b/tests/testFilteringCatalogs.py
@@ -288,6 +288,9 @@ class InstanceCatalogTestCase(unittest.TestCase):
                 ii = 4 + i_line
                 self.assertEqual(line, '%d, %d\n' % (ii, ii+1))
 
+        if os.path.exists(cat_name):
+            os.unlink(cat_name)
+
 
 class CompoundInstanceCatalogTestCase(unittest.TestCase):
     """

--- a/tests/testFilteringCatalogs.py
+++ b/tests/testFilteringCatalogs.py
@@ -332,6 +332,46 @@ class InstanceCatalogTestCase(unittest.TestCase):
         if os.path.exists(cat_name):
             os.unlink(cat_name)
 
+    def test_adding_filter(self):
+        """
+        Test that, when we use the kwarg in the constructor to add to
+        cannot_be_null, the filter is appended to existing filters.
+        """
+        class FilteredCat8(InstanceCatalog):
+            column_outputs = ['id', 'ip1']
+            cannot_be_null = ['filter1']
+
+            def get_filter1(self):
+                ii = self.column_by_name('ip2')
+                return np.where(ii%2 == 0, ii, None)
+
+            def get_filter2(self):
+                ii = self.column_by_name('ip3')
+                return np.where(ii > 8, ii, None)
+
+        cat_name = os.path.join(self.scratch_dir, "inst_adding_filter_cat.txt")
+        if os.path.exists(cat_name):
+            os.unlink(cat_name)
+
+        cat = FilteredCat8(self.db, cannot_be_null = ['filter2'])
+        self.assertIn('filter1', cat._cannot_be_null)
+        self.assertIn('filter2', cat._cannot_be_null)
+
+        cat.write_catalog(cat_name)
+        with open(cat_name, 'r') as input_file:
+            input_lines = input_file.readlines()
+        self.assertEqual(len(input_lines), 3)
+        for i_line, line in enumerate(input_lines):
+            if i_line is 0:
+                continue
+            else:
+                ii = (i_line - 1)*2 + 6
+                self.assertEqual((ii+2) % 2, 0)
+                self.assertGreater(ii+3, 8)
+                self.assertEqual(line, '%d, %d\n' % (ii, ii+1))
+
+        if os.path.exists(cat_name):
+            os.unlink(cat_name)
 
 class CompoundInstanceCatalogTestCase(unittest.TestCase):
     """

--- a/tests/testFilteringCatalogs.py
+++ b/tests/testFilteringCatalogs.py
@@ -77,6 +77,7 @@ class InstanceCatalogTestCase(unittest.TestCase):
                 continue
             else:
                 ii = i_line - 1
+                self.assertLess(ii, 5)
                 self.assertEqual(line,
                                  '%d, %d, %d, %d\n' % (ii, ii+1, ii+2, ii+3))
 
@@ -120,6 +121,8 @@ class InstanceCatalogTestCase(unittest.TestCase):
                 ip1 = ii + 1
                 ip2 = ii + 2
                 ip3 = ii + 3
+                self.assertEqual((ii+2) % 2, 0)
+                self.assertEqual((ii+3) % 3, 0)
                 self.assertEqual(line,
                                  '%d, %d, %d, %d\n' % (ii, ip1, ip2, ip3))
 
@@ -163,6 +166,8 @@ class InstanceCatalogTestCase(unittest.TestCase):
                 ip1 = ii + 1
                 ip2 = ii + 2
                 ip3 = ii + 3
+                self.assertEqual((ii+2) % 2, 0)
+                self.assertEqual((ii+3) % 3, 0)
                 self.assertEqual(line,
                                  '%d, %d, %d, %d\n' % (ii, ip1, ip2, ip3))
 
@@ -207,6 +212,7 @@ class InstanceCatalogTestCase(unittest.TestCase):
             else:
                 ii = (i_line - 1)*3
                 ip3 = ii + 3
+                self.assertEqual((ip3*ip3) % 3, 0)
                 self.assertEqual(line, '%d, %d, %d, %d, %.1f\n'
                                         % (ii, ip3*ip3, ip3*ip3*ip3, ip3*ip3*ip3*ip3, 0.5*(ip3*ip3)))
 
@@ -248,6 +254,7 @@ class InstanceCatalogTestCase(unittest.TestCase):
             else:
                 ii = (i_line - 1)*3
                 ip3 = ii + 3
+                self.assertEqual((ip3**4) % 3, 0)
                 self.assertEqual(line, '%d, %d, %d, %d\n'
                                         % (ii, ip3*ip3, ip3*ip3*ip3, ip3*ip3*ip3*ip3))
 
@@ -286,6 +293,7 @@ class InstanceCatalogTestCase(unittest.TestCase):
                 continue
             else:
                 ii = 4 + i_line
+                self.assertGreater(ii+1, 5)
                 self.assertEqual(line, '%d, %d\n' % (ii, ii+1))
 
         if os.path.exists(cat_name):
@@ -441,13 +449,16 @@ class CompoundInstanceCatalogTestCase(unittest.TestCase):
                 continue
             elif i_line < 6:
                 ii = 2*(i_line-1) + 1
+                self.assertEqual((ii+1) % 2, 0)
                 self.assertEqual(line, '%d, %d\n' % (ii, ii+1))
             elif i_line < 10:
                 ii = i_line - 6
+                self.assertLess(ii, 4)
                 self.assertEqual(line, '%d, %d\n' % (ii, ii+2))
             else:
-                ii = i_line - 10
-                self.assertEqual(line, '%d, %d\n' % (ii+6, ii+6+3))
+                ii = i_line - 10 + 6
+                self.assertGreater(ii, 5)
+                self.assertEqual(line, '%d, %d\n' % (ii, ii+3))
 
         if os.path.exists(cat_name):
             os.unlink(cat_name)

--- a/tests/testFilteringCatalogs.py
+++ b/tests/testFilteringCatalogs.py
@@ -78,6 +78,8 @@ class InstanceCatalogTestCase(unittest.TestCase):
                 self.assertEqual(line,
                                  '%d, %d, %d, %d\n' % (ii, ii+1, ii+2, ii+3))
 
+        if os.path.exists(cat_name):
+            os.unlink(cat_name)
 
 class CompoundInstanceCatalogTestCase(unittest.TestCase):
     """

--- a/tests/testFilteringCatalogs.py
+++ b/tests/testFilteringCatalogs.py
@@ -122,6 +122,47 @@ class InstanceCatalogTestCase(unittest.TestCase):
         if os.path.exists(cat_name):
             os.unlink(cat_name)
 
+    def test_post_facto_filters(self):
+        """
+        Test a case where filters are declared after instantiation
+        """
+        class FilteredCat3(InstanceCatalog):
+            column_outputs = ['id', 'ip1', 'ip2t', 'ip3t']
+
+            def get_ip2t(self):
+                base = self.column_by_name('ip2')
+                return np.where(base % 2 == 0, base, None)
+
+            def get_ip3t(self):
+                base = self.column_by_name('ip3')
+                return np.where(base % 3 == 0, base, None)
+
+        cat_name = os.path.join(self.scratch_dir, "inst_post_facto_filter_cat.txt")
+        if os.path.exists(cat_name):
+            os.unlink(cat_name)
+
+        cat = FilteredCat3(self.db)
+        cat.cannot_be_null = ['ip2t', 'ip3t']
+        cat.write_catalog(cat_name)
+
+        with open(cat_name, 'r') as input_file:
+            input_lines = input_file.readlines()
+
+        self.assertEqual(len(input_lines), 3)  # two data lines and a header
+        for i_line, line in enumerate(input_lines):
+            if i_line is 0:
+                continue
+            else:
+                ii = (i_line - 1)*6
+                ip1 = ii + 1
+                ip2 = ii + 2
+                ip3 = ii + 3
+                self.assertEqual(line,
+                                 '%d, %d, %d, %d\n' % (ii, ip1, ip2, ip3))
+
+        if os.path.exists(cat_name):
+            os.unlink(cat_name)
+
 
 class CompoundInstanceCatalogTestCase(unittest.TestCase):
     """

--- a/tests/testFilteringCatalogs.py
+++ b/tests/testFilteringCatalogs.py
@@ -7,7 +7,7 @@ import lsst.utils.tests
 from lsst.utils import getPackageDir
 from lsst.sims.catalogs.definitions import InstanceCatalog, CompoundInstanceCatalog
 from lsst.sims.catalogs.db import fileDBObject, CatalogDBObject
-from lsst.sims.catalogs.decorators import compound
+from lsst.sims.catalogs.decorators import cached, compound
 
 
 def setup_module(module):
@@ -55,6 +55,7 @@ class InstanceCatalogTestCase(unittest.TestCase):
             column_outputs = ['id', 'ip1', 'ip2', 'ip3t']
             cannot_be_null = ['ip3t']
 
+            @cached
             def get_ip3t(self):
                 base = self.column_by_name('ip3')
                 ii = self.column_by_name('id')
@@ -90,10 +91,12 @@ class InstanceCatalogTestCase(unittest.TestCase):
             column_outputs = ['id', 'ip1', 'ip2t', 'ip3t']
             cannot_be_null = ['ip2t', 'ip3t']
 
+            @cached
             def get_ip2t(self):
                 base = self.column_by_name('ip2')
                 return np.where(base % 2 == 0, base, None)
 
+            @cached
             def get_ip3t(self):
                 base = self.column_by_name('ip3')
                 return np.where(base % 3 == 0, base, None)
@@ -130,10 +133,12 @@ class InstanceCatalogTestCase(unittest.TestCase):
         class FilteredCat3(InstanceCatalog):
             column_outputs = ['id', 'ip1', 'ip2t', 'ip3t']
 
+            @cached
             def get_ip2t(self):
                 base = self.column_by_name('ip2')
                 return np.where(base % 2 == 0, base, None)
 
+            @cached
             def get_ip3t(self):
                 base = self.column_by_name('ip3')
                 return np.where(base % 3 == 0, base, None)
@@ -179,6 +184,7 @@ class InstanceCatalogTestCase(unittest.TestCase):
                 ii = self.column_by_name('ip3')
                 return np.array([ii*ii, ii*ii*ii, ii*ii*ii*ii])
 
+            @cached
             def get_filter_col(self):
                 base = self.column_by_name('a')
                 return np.where(base % 3 == 0, base/2.0, None)
@@ -252,6 +258,7 @@ class CompoundInstanceCatalogTestCase(unittest.TestCase):
             column_outputs = ['id', 'ip1t']
             cannot_be_null = ['ip1t']
 
+            @cached
             def get_ip1t(self):
                 base = self.column_by_name('ip1')
                 output = []
@@ -266,6 +273,7 @@ class CompoundInstanceCatalogTestCase(unittest.TestCase):
             column_outputs = ['id', 'ip2t']
             cannot_be_null = ['ip2t']
 
+            @cached
             def get_ip2t(self):
                 base = self.column_by_name('ip2')
                 ii = self.column_by_name('id')
@@ -275,6 +283,7 @@ class CompoundInstanceCatalogTestCase(unittest.TestCase):
             column_outputs = ['id', 'ip3t']
             cannot_be_null = ['ip3t']
 
+            @cached
             def get_ip3t(self):
                 base = self.column_by_name('ip3')
                 ii = self.column_by_name('id')

--- a/tests/testFilteringCatalogs.py
+++ b/tests/testFilteringCatalogs.py
@@ -1,0 +1,149 @@
+from __future__ import with_statement
+import unittest
+import numpy as np
+import os
+
+import lsst.utils.tests
+from lsst.utils import getPackageDir
+from lsst.sims.catalogs.definitions import InstanceCatalog, CompoundInstanceCatalog
+from lsst.sims.catalogs.db import fileDBObject, CatalogDBObject
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+class CompoundInstanceCatalogTestCase(unittest.TestCase):
+    """
+    This class will contain tests that will help us verify that using
+    cannot_be_null to filter the contents of a CompoundInstanceCatalog
+    works as it should.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.scratch_dir = os.path.join(getPackageDir('sims_catalogs'), 'tests', 'scratchSpace')
+
+        cls.db_src_name = os.path.join(cls.scratch_dir, 'compound_cat_filter_db.txt')
+        if os.path.exists(cls.db_src_name):
+            os.unlink(cls.db_src_name)
+
+        cls.db_name = os.path.join(cls.scratch_dir, 'compound_cat_filter_db.db')
+        if os.path.exists(cls.db_name):
+            os.unlink(cls.db_name)
+
+        with open(cls.db_src_name, 'w') as output_file:
+            output_file.write('#a header\n')
+            for ii in range(10):
+                output_file.write('%d %d %d %d\n' % (ii, ii+1, ii+2, ii+3))
+
+        dtype = np.dtype([('id', int), ('ip1', int), ('ip2', int), ('ip3', int)])
+        fileDBObject(cls.db_src_name, runtable='test', dtype=dtype,
+                     idColKey='id', database=cls.db_name)
+
+    @classmethod
+    def tearDownClass(cls):
+
+        if os.path.exists(cls.db_src_name):
+            os.unlink(cls.db_src_name)
+
+        if os.path.exists(cls.db_name):
+            os.unlink(cls.db_name)
+
+    def test_compound_cat(self):
+        """
+        Test that a CompoundInstanceCatalog made up of InstanceCatalog classes that
+        each filter on a different condition gives the correct outputs.
+        """
+
+        class CatClass1(InstanceCatalog):
+            column_outputs = ['id', 'ip1t']
+            cannot_be_null = ['ip1t']
+
+            def get_ip1t(self):
+                base = self.column_by_name('ip1')
+                output = []
+                for bb in base:
+                    if bb%2 == 0:
+                        output.append(bb)
+                    else:
+                        output.append(None)
+                return np.array(output)
+
+        class CatClass2(InstanceCatalog):
+            column_outputs = ['id', 'ip2t']
+            cannot_be_null = ['ip2t']
+
+            def get_ip2t(self):
+                base = self.column_by_name('ip2')
+                ii = self.column_by_name('id')
+                return np.where(ii < 4, base, None)
+
+        class CatClass3(InstanceCatalog):
+            column_outputs = ['id', 'ip3t']
+            cannot_be_null = ['ip3t']
+
+            def get_ip3t(self):
+                base = self.column_by_name('ip3')
+                ii = self.column_by_name('id')
+                return np.where(ii > 5, base, None)
+
+        class DbClass(CatalogDBObject):
+            host = None
+            port = None
+            database = self.db_name
+            driver = 'sqlite'
+            tableid = 'test'
+            objid = 'silliness'
+            idColKey = 'id'
+
+        class DbClass1(DbClass):
+            objid = 'silliness1'
+
+        class DbClass2(DbClass):
+            objid = 'silliness2'
+
+        class DbClass3(DbClass):
+            objid = 'silliness3'
+
+        cat = CompoundInstanceCatalog([CatClass1, CatClass2, CatClass3],
+                                      [DbClass1, DbClass2, DbClass3])
+
+        cat_name = os.path.join(self.scratch_dir, "compound_filter_output.txt")
+        if os.path.exists(cat_name):
+            os.unlink(cat_name)
+
+        cat.write_catalog(cat_name)
+
+        with open(cat_name, 'r') as input_file:
+            input_lines = input_file.readlines()
+
+        self.assertEqual(len(input_lines), 14)
+
+        # given that we know what the contents of each sub-catalog should be
+        # and how they should be ordered, loop through the lines of the output
+        # catalog, verifying that every line is where it ought to be
+        for i_line, line in enumerate(input_lines):
+            if i_line is 0:
+                continue
+            elif i_line < 6:
+                ii = 2*(i_line-1) + 1
+                self.assertEqual(line, '%d, %d\n' % (ii, ii+1))
+            elif i_line < 10:
+                ii = i_line - 6
+                self.assertEqual(line, '%d, %d\n' % (ii, ii+2))
+            else:
+                ii = i_line - 10
+                self.assertEqual(line, '%d, %d\n' % (ii+6, ii+6+3))
+
+        if os.path.exists(cat_name):
+            os.unlink(cat_name)
+
+
+class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/testFilteringCatalogs.py
+++ b/tests/testFilteringCatalogs.py
@@ -131,7 +131,7 @@ class InstanceCatalogTestCase(unittest.TestCase):
 
     def test_post_facto_filters(self):
         """
-        Test a case where filters are declared after instantiation
+        Test a case where filters are declared at instantiation
         """
         class FilteredCat3(InstanceCatalog):
             column_outputs = ['id', 'ip1', 'ip2t', 'ip3t']
@@ -150,8 +150,7 @@ class InstanceCatalogTestCase(unittest.TestCase):
         if os.path.exists(cat_name):
             os.unlink(cat_name)
 
-        cat = FilteredCat3(self.db)
-        cat.cannot_be_null = ['ip2t', 'ip3t']
+        cat = FilteredCat3(self.db, cannot_be_null=['ip2t', 'ip3t'])
         cat.write_catalog(cat_name)
 
         with open(cat_name, 'r') as input_file:

--- a/tests/testFilteringCatalogs.py
+++ b/tests/testFilteringCatalogs.py
@@ -210,6 +210,9 @@ class InstanceCatalogTestCase(unittest.TestCase):
                 self.assertEqual(line, '%d, %d, %d, %d, %.1f\n'
                                         % (ii, ip3*ip3, ip3*ip3*ip3, ip3*ip3*ip3*ip3, 0.5*(ip3*ip3)))
 
+        if os.path.exists(cat_name):
+            os.unlink(cat_name)
+
     def test_filter_on_compound_column(self):
         """
         Test filtering on a catalog that filters on a compound column

--- a/tests/testInstanceCatalog.py
+++ b/tests/testInstanceCatalog.py
@@ -422,8 +422,7 @@ class InstanceCatalogCannotBeNullTest(unittest.TestCase):
         def testCannotBeNull_pre_screen(self):
             """
             Check that writing a catalog with self._pre_screen = True produces
-            the same results as writing one with self._pre_screen = False, except
-            with a smaller self._current_chunk.
+            the same results as writing one with self._pre_screen = False.
             """
 
             scratch_dir = os.path.join(getPackageDir('sims_catalogs'), 'tests', 'scratchSpace')
@@ -441,10 +440,6 @@ class InstanceCatalogCannotBeNullTest(unittest.TestCase):
                 control_fileName = os.path.join(scratch_dir, 'cannotBeNullTestFile_prescreen_control.txt')
                 cat.write_catalog(fileName)
                 control_cat.write_catalog(control_fileName)
-
-                # make sure that pre-screened catalog passed fewer rows into
-                # self._current_chunk than did the non-pre-screened catalog
-                self.assertGreater(control_cat._current_chunk.size, cat._current_chunk.size)
 
                 with open(fileName, 'r') as test_file:
                     test_lines = test_file.readlines()

--- a/tests/testParallelCatalogWriter.py
+++ b/tests/testParallelCatalogWriter.py
@@ -90,15 +90,15 @@ class ParallelWriterTestCase(unittest.TestCase):
 
         db = DbClass()
 
-        class_dict = {os.path.join(self.scratch_dir, 'par_test1.txt'): CatClass1,
-                      os.path.join(self.scratch_dir, 'par_test2.txt'): CatClass2,
-                      os.path.join(self.scratch_dir, 'par_test3.txt'): CatClass3}
+        class_dict = {os.path.join(self.scratch_dir, 'par_test1.txt'): CatClass1(db),
+                      os.path.join(self.scratch_dir, 'par_test2.txt'): CatClass2(db),
+                      os.path.join(self.scratch_dir, 'par_test3.txt'): CatClass3(db)}
 
         for file_name in class_dict:
             if os.path.exists(file_name):
                 os.unlink(file_name)
 
-        parallelCatalogWriter(class_dict, db)
+        parallelCatalogWriter(class_dict)
 
         dtype = np.dtype([('id', int), ('test', int), ('ii', int)])
         data1 = np.genfromtxt(os.path.join(self.scratch_dir, 'par_test1.txt'), dtype=dtype, delimiter=',')

--- a/tests/testParallelCatalogWriter.py
+++ b/tests/testParallelCatalogWriter.py
@@ -1,0 +1,150 @@
+from __future__ import with_statement
+import unittest
+import sqlite3
+import os
+import numpy as np
+
+import lsst.utils.tests
+from lsst.utils import getPackageDir
+from lsst.sims.catalogs.definitions import parallelCatalogWriter
+from lsst.sims.catalogs.definitions import InstanceCatalog
+from lsst.sims.catalogs.decorators import compound, cached
+from lsst.sims.catalogs.db import CatalogDBObject
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+class ParallelWriterTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.scratch_dir = os.path.join(getPackageDir('sims_catalogs'),
+                                       'tests', 'scratchSpace')
+
+        cls.db_name = os.path.join(cls.scratch_dir, 'parallel_test_db.db')
+        if os.path.exists(cls.db_name):
+            os.unlink(cls.db_name)
+
+        rng = np.random.RandomState(88)
+        conn = sqlite3.connect(cls.db_name)
+        c = conn.cursor()
+        c.execute('''CREATE TABLE test (id int, ii int)''')
+        for ii in range(100):
+            c.execute('''INSERT INTO test VALUES(%i, %i)''' % (ii, rng.random_integers(0,100)))
+
+        conn.commit()
+        conn.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.exists(cls.db_name):
+            os.unlink(cls.db_name)
+
+    def test_parallel_writing(self):
+        """
+        Test that parallelCatalogWriter gets the right columns in it
+        """
+        class DbClass(CatalogDBObject):
+            tableid = 'test'
+            database = self.db_name
+            host = None
+            port = None
+            driver = 'sqlite'
+            objid = 'paralle_writer_test_db'
+            idColKey = 'id'
+
+        class CatClass1(InstanceCatalog):
+            column_outputs = ['id', 'test1', 'ii']
+            cannot_be_null = ['valid1']
+
+            @compound('test1', 'valid1')
+            def get_values(self):
+                ii = self.column_by_name('ii')
+                return np.array([self.column_by_name('id')**2,
+                                 np.where(ii%2==1, ii, None)])
+
+        class CatClass2(InstanceCatalog):
+            column_outputs = ['id', 'test2', 'ii']
+            cannot_be_null = ['valid2']
+
+            @compound('test2', 'valid2')
+            def get_values(self):
+                ii = self.column_by_name('id')
+                return np.array([self.column_by_name('id')**3,
+                                 np.where(ii%2==1, ii, None)])
+
+        class CatClass3(InstanceCatalog):
+            column_outputs = ['id', 'test3', 'ii']
+            cannot_be_null = ['valid3']
+
+            @cached
+            def get_test3(self):
+                return self.column_by_name('id')**4
+
+            @cached
+            def get_valid3(self):
+                ii = self.column_by_name('id')
+                return np.where(ii%5 == 0, ii, None)
+
+        db = DbClass()
+
+        class_dict = {os.path.join(self.scratch_dir, 'par_test1.txt'): CatClass1,
+                      os.path.join(self.scratch_dir, 'par_test2.txt'): CatClass2,
+                      os.path.join(self.scratch_dir, 'par_test3.txt'): CatClass3}
+
+        for file_name in class_dict:
+            if os.path.exists(file_name):
+                os.unlink(file_name)
+
+        parallelCatalogWriter(class_dict, db)
+
+        dtype = np.dtype([('id', int), ('test', int), ('ii', int)])
+        data1 = np.genfromtxt(os.path.join(self.scratch_dir, 'par_test1.txt'), dtype=dtype, delimiter=',')
+        data2 = np.genfromtxt(os.path.join(self.scratch_dir, 'par_test2.txt'), dtype=dtype, delimiter=',')
+        data3 = np.genfromtxt(os.path.join(self.scratch_dir, 'par_test3.txt'), dtype=dtype, delimiter=',')
+
+        # verify that all three catalogs got the same objects
+        np.testing.assert_array_equal(data1['id'], data2['id'])
+        np.testing.assert_array_equal(data2['id'], data3['id'])
+
+        # verify that the contents of the catalogs fit with the constraints in cannot_be_null
+        self.assertEqual(len(np.where(data1['id']%2 == 0)[0]), 0)
+        self.assertEqual(len(np.where(data1['id']%5 != 0)[0]), 0)
+        self.assertEqual(len(np.where(data1['ii']%2 == 0)[0]), 0)
+
+        # verify that the added value columns came out to the correct value
+        np.testing.assert_array_equal(data1['id']**2, data1['test'])
+        np.testing.assert_array_equal(data2['id']**3, data2['test'])
+        np.testing.assert_array_equal(data3['id']**4, data3['test'])
+
+        # now verify that all of the rows that were excluded from our catalogs
+        # really should have been excluded
+        class ControlCatalog(InstanceCatalog):
+            column_outputs = ['id', 'ii']
+
+        control_cat = ControlCatalog(db)
+        iterator = control_cat.iter_catalog()
+        ct = 0
+        ct_in = 0
+        for control_data in iterator:
+            ct += 1
+            if control_data[0] in data1['id']:
+                ct_in += 1
+            else:
+                is_valid = ((control_data[0]%2 == 1) and
+                            (control_data[0]%5 == 0) and
+                            (control_data[1]%2 == 1))
+                
+                self.assertFalse(is_valid, msg='Column filtering missed a row')
+
+        self.assertEqual(ct_in, len(data1['id']))
+        self.assertEqual(ct, 100)
+
+class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
+    pass
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/testParallelCatalogWriter.py
+++ b/tests/testParallelCatalogWriter.py
@@ -24,7 +24,7 @@ class DbClass(CatalogDBObject):
     host = None
     port = None
     driver = 'sqlite'
-    objid = 'paralle_writer_test_db'
+    objid = 'parallel_writer_test_db'
     idColKey = 'id'
 
 class CatClass1(InstanceCatalog):

--- a/tests/testParallelCatalogWriter.py
+++ b/tests/testParallelCatalogWriter.py
@@ -16,6 +16,54 @@ def setup_module(module):
     lsst.utils.tests.init()
 
 
+class DbClass(CatalogDBObject):
+    tableid = 'test'
+    database = os.path.join(getPackageDir('sims_catalogs'),
+                            'tests', 'scratchSpace', 'parallel_test_db.db')
+
+    host = None
+    port = None
+    driver = 'sqlite'
+    objid = 'paralle_writer_test_db'
+    idColKey = 'id'
+
+class CatClass1(InstanceCatalog):
+    column_outputs = ['id', 'test1', 'ii']
+    cannot_be_null = ['valid1']
+
+    @compound('test1', 'valid1')
+    def get_values(self):
+        ii = self.column_by_name('ii')
+        return np.array([self.column_by_name('id')**2,
+                         np.where(ii%2==1, ii, None)])
+
+class CatClass2(InstanceCatalog):
+    column_outputs = ['id', 'test2', 'ii']
+    cannot_be_null = ['valid2']
+
+    @compound('test2', 'valid2')
+    def get_values(self):
+        ii = self.column_by_name('id')
+        return np.array([self.column_by_name('id')**3,
+                         np.where(ii%2==1, ii, None)])
+
+class CatClass3(InstanceCatalog):
+    column_outputs = ['id', 'test3', 'ii']
+    cannot_be_null = ['valid3']
+
+    @cached
+    def get_test3(self):
+        return self.column_by_name('id')**4
+
+    @cached
+    def get_valid3(self):
+        ii = self.column_by_name('id')
+        return np.where(ii%5 == 0, ii, None)
+
+class ControlCatalog(InstanceCatalog):
+    column_outputs = ['id', 'ii']
+
+
 class ParallelWriterTestCase(unittest.TestCase):
 
     @classmethod
@@ -46,47 +94,6 @@ class ParallelWriterTestCase(unittest.TestCase):
         """
         Test that parallelCatalogWriter gets the right columns in it
         """
-        class DbClass(CatalogDBObject):
-            tableid = 'test'
-            database = self.db_name
-            host = None
-            port = None
-            driver = 'sqlite'
-            objid = 'paralle_writer_test_db'
-            idColKey = 'id'
-
-        class CatClass1(InstanceCatalog):
-            column_outputs = ['id', 'test1', 'ii']
-            cannot_be_null = ['valid1']
-
-            @compound('test1', 'valid1')
-            def get_values(self):
-                ii = self.column_by_name('ii')
-                return np.array([self.column_by_name('id')**2,
-                                 np.where(ii%2==1, ii, None)])
-
-        class CatClass2(InstanceCatalog):
-            column_outputs = ['id', 'test2', 'ii']
-            cannot_be_null = ['valid2']
-
-            @compound('test2', 'valid2')
-            def get_values(self):
-                ii = self.column_by_name('id')
-                return np.array([self.column_by_name('id')**3,
-                                 np.where(ii%2==1, ii, None)])
-
-        class CatClass3(InstanceCatalog):
-            column_outputs = ['id', 'test3', 'ii']
-            cannot_be_null = ['valid3']
-
-            @cached
-            def get_test3(self):
-                return self.column_by_name('id')**4
-
-            @cached
-            def get_valid3(self):
-                ii = self.column_by_name('id')
-                return np.where(ii%5 == 0, ii, None)
 
         db = DbClass()
 
@@ -117,8 +124,80 @@ class ParallelWriterTestCase(unittest.TestCase):
 
         # now verify that all of the rows that were excluded from our catalogs
         # really should have been excluded
-        class ControlCatalog(InstanceCatalog):
-            column_outputs = ['id', 'ii']
+
+        control_cat = ControlCatalog(db)
+        iterator = control_cat.iter_catalog()
+        ct = 0
+        ct_in_1 = 0
+        ct_in_2 = 0
+        ct_in_3 = 0
+        for control_data in iterator:
+            ct += 1
+
+            if control_data[1] % 2 == 0:
+                self.assertNotIn(control_data[0], data1['id'])
+            else:
+                ct_in_1 += 1
+                self.assertIn(control_data[0], data1['id'])
+                dex = np.where(data1['id']==control_data[0])[0][0]
+                self.assertEqual(control_data[1], data1['ii'][dex])
+
+            if control_data[0] % 2 == 0:
+                self.assertNotIn(control_data[0], data2['id'])
+            else:
+                ct_in_2 += 1
+                self.assertIn(control_data[0], data2['id'])
+                dex = np.where(data2['id']==control_data[0])[0][0]
+                self.assertEqual(control_data[1], data2['ii'][dex])
+
+            if control_data[0] % 5 != 0:
+                self.assertNotIn(control_data[0], data3['id'])
+            else:
+                ct_in_3 += 1
+                self.assertIn(control_data[0], data3['id'])
+                dex = np.where(data3['id']==control_data[0])[0][0]
+                self.assertEqual(control_data[1], data3['ii'][dex])
+
+        self.assertEqual(ct_in_1, len(data1['id']))
+        self.assertEqual(ct_in_2, len(data2['id']))
+        self.assertEqual(ct_in_3, len(data3['id']))
+        self.assertEqual(ct, 100)
+
+    def test_parallel_writing_chunk_size(self):
+        """
+        Test that parallelCatalogWriter gets the right columns in it
+        when chunk_size is not None (this is a repeat of test_parallel_writing)
+        """
+
+        db = DbClass()
+
+        class_dict = {os.path.join(self.scratch_dir, 'par_test1.txt'): CatClass1(db),
+                      os.path.join(self.scratch_dir, 'par_test2.txt'): CatClass2(db),
+                      os.path.join(self.scratch_dir, 'par_test3.txt'): CatClass3(db)}
+
+        for file_name in class_dict:
+            if os.path.exists(file_name):
+                os.unlink(file_name)
+
+        parallelCatalogWriter(class_dict, chunk_size=7)
+
+        dtype = np.dtype([('id', int), ('test', int), ('ii', int)])
+        data1 = np.genfromtxt(os.path.join(self.scratch_dir, 'par_test1.txt'), dtype=dtype, delimiter=',')
+        data2 = np.genfromtxt(os.path.join(self.scratch_dir, 'par_test2.txt'), dtype=dtype, delimiter=',')
+        data3 = np.genfromtxt(os.path.join(self.scratch_dir, 'par_test3.txt'), dtype=dtype, delimiter=',')
+
+        # verify that the contents of the catalogs fit with the constraints in cannot_be_null
+        self.assertEqual(len(np.where(data1['ii']%2 == 0)[0]), 0)
+        self.assertEqual(len(np.where(data2['id']%2 == 0)[0]), 0)
+        self.assertEqual(len(np.where(data3['id']%5 != 0)[0]), 0)
+
+        # verify that the added value columns came out to the correct value
+        np.testing.assert_array_equal(data1['id']**2, data1['test'])
+        np.testing.assert_array_equal(data2['id']**3, data2['test'])
+        np.testing.assert_array_equal(data3['id']**4, data3['test'])
+
+        # now verify that all of the rows that were excluded from our catalogs
+        # really should have been excluded
 
         control_cat = ControlCatalog(db)
         iterator = control_cat.iter_catalog()


### PR DESCRIPTION
This is one of many (one for each sims_* repo...) PRs related to my effort to create a seamless integration between OpSim, CatSim, and PhoSim for generating full-focal plane image simulations.

This (sims_catalogs) pull request:

1) Changes how InstanceCatalog filters rows on `cannot_be_null` to be a little more efficient.

2) Adds a `parallel_catalog_writer()` which can write many InstanceCatalogs based on the same database connection (i.e. if you wanted to produce a PhoSim InstanceCatalog and a reference catalog of true magnitudes for the same objects without having to open the database connection twice).  This is analogous to the `CompoundInstanceCatalog`, except that the `CompoundInstanceCatalog` writes everything to one file.  The `parallel_catalog_writer` writes separate files.

3) Makes a cache of database connections that is a class attribute of `CatalogDBObject` which `CatalogDBObject` automatically uses.  Users no longer have to be careful about passing connections around to prevent redundant connections from opening (note that `DBObject` does not use the cache of connections).