### PR TITLE
Wrap test code objid in ints.

### DIFF
--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -617,7 +617,7 @@ class CompoundWithObsMetaData(unittest.TestCase):
         good_rows = []
         for chunk in results:
             for line in chunk:
-                ix = line['id']
+                ix = int(line['id'])
                 good_rows.append(ix)
                 self.assertAlmostEqual(line['%s_raJ2000' % db1.objid], self.controlArray['ra'][ix], 10)
                 self.assertAlmostEqual(line['%s_decJ2000' % db1.objid], self.controlArray['dec'][ix], 10)
@@ -670,7 +670,7 @@ class CompoundWithObsMetaData(unittest.TestCase):
         good_rows = []
         for chunk in results:
             for line in chunk:
-                ix = line['id']
+                ix = int(line['id'])
                 good_rows.append(ix)
                 self.assertAlmostEqual(line['%s_raJ2000' % db1.objid], self.controlArray['ra'][ix], 10)
                 self.assertAlmostEqual(line['%s_decJ2000' % db1.objid], self.controlArray['dec'][ix], 10)
@@ -726,7 +726,7 @@ class CompoundWithObsMetaData(unittest.TestCase):
         good_rows = []
         for chunk in results:
             for line in chunk:
-                ix = line['id']
+                ix = int(line['id'])
                 good_rows.append(ix)
                 self.assertAlmostEqual(line['%s_raJ2000' % db1.objid], self.controlArray['ra'][ix], 10)
                 self.assertAlmostEqual(line['%s_decJ2000' % db1.objid], self.controlArray['dec'][ix], 10)


### PR DESCRIPTION
Numpy >=1.12 disallows float indexing.

@danielsf I've wrapped indexes in these test cases here, and the tests now pass.

But the real question is that given that the index used a lookup of the 'objid' column in the database, what other code in `sims_catalogs` or users of `sims_catalogs` have this indexing issue?