### PR TITLE
U/danielsf/debug/mba validation

### DIFF
--- a/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
@@ -624,6 +624,15 @@ class InstanceCatalog(with_metaclass(InstanceCatalogMeta, object)):
         self._write_current_chunk(file_handle)
 
     def iter_catalog(self, chunk_size=None):
+        """
+        Iterate over the lines of a catalog.
+
+        chunk_size controls the number of rows returned at a
+        time from the database (smaller chunk_size will result
+        in less memory usage but slower performance).
+
+        Catalog rows will be returned as lists.
+        """
         self.db_required_columns()
 
         query_result = self.db_obj.query_columns(colnames=self._active_columns,

--- a/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
@@ -652,6 +652,28 @@ class InstanceCatalog(with_metaclass(InstanceCatalogMeta, object)):
                 yield line
 
     def iter_catalog_chunks(self, chunk_size=None):
+        """
+        Iterate over catalog contents one chunk at a time.
+
+        chunk_size controls the number of catalog rows contained
+        in each chunk.
+
+        The iterator will return a chunk of the database (a list of lists
+        containing the contents of the datbase chunk).  The first dimension
+        of the chunk corresponds to the columns of the catalog, i.e. chunk[0]
+        is a list containing the 0th column of the catalog.
+
+        The iterator will also yield a colMap, which is a dict mapping the
+        names of the columns to their index value in the chunk.
+
+        Usage:
+
+        for chunk, colMap in cat.iter_catalog_chunks(chunk_size=1000):
+            for ix in range(len(chunk[0])):
+                print chunk[0][ix], chunk[1][ix], chunk[2][ix]
+
+        will print out the first three columns of the catalog, row by row
+        """
         self.db_required_columns()
 
         query_result = self.db_obj.query_columns(colnames=self._active_columns,

--- a/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
@@ -634,7 +634,7 @@ class InstanceCatalog(with_metaclass(InstanceCatalogMeta, object)):
         list_of_transform_keys = list(self.transformations.keys())
 
         for chunk in query_result:
-            self._set_current_chunk(chunk)
+            self._filter_chunk(chunk)
             chunk_cols = [self.transformations[col](self.column_by_name(col))
                           if col in list_of_transform_keys else
                           self.column_by_name(col)
@@ -653,7 +653,7 @@ class InstanceCatalog(with_metaclass(InstanceCatalogMeta, object)):
         list_of_transform_keys = list(self.transformations.keys())
 
         for chunk in query_result:
-            self._set_current_chunk(chunk)
+            self._filter_chunk(chunk)
             chunk_cols = [self.transformations[col](self.column_by_name(col))
                           if col in list_of_transform_keys else
                           self.column_by_name(col)

--- a/tests/testCatalogs.py
+++ b/tests/testCatalogs.py
@@ -315,6 +315,39 @@ class InstanceCatalogTestCase(unittest.TestCase):
         if os.path.exists(cat_name):
             os.unlink(cat_name)
 
+    def test_iter_catalog_chunks(self):
+        """
+        Test that iter_catalog_chunks returns the same results as write_catalog
+        """
+
+        obs = ObservationMetaData(pointingRA=10.0, pointingDec=-20.0,
+                                  boundLength=50.0, boundType='circle')
+
+        cat = BasicCatalog(self.starDB, obs_metadata=obs)
+        cat_name = os.path.join(self.scratch_dir, 'iter_catalog_chunks_control.txt')
+        cat.write_catalog(cat_name)
+        with open(cat_name, 'r') as in_file:
+            in_lines = in_file.readlines()
+        self.assertGreater(len(in_lines), 1)
+        self.assertLess(len(in_lines), len(self.starControlData))
+
+        cat = BasicCatalog(self.starDB, obs_metadata=obs)
+        line_ct = 0
+        for chunk, chunk_map in cat.iter_catalog_chunks(chunk_size=7):
+            for ix in range(len(chunk[0])):
+                str_line = '%d, %.12f, %.12f, %.12f, %.12f, %.12f, %.12f, %.12f, %.12f\n' % \
+                (chunk[0][ix], chunk[1][ix], chunk[2][ix], chunk[3][ix], chunk[4][ix],
+                 chunk[5][ix], chunk[6][ix], chunk[7][ix], chunk[8][ix])
+
+                self.assertIn(str_line, in_lines)
+                line_ct += 1
+
+        self.assertEqual(line_ct, len(in_lines)-1)
+
+        if os.path.exists(cat_name):
+            os.unlink(cat_name)
+
+
 
 class boundingBoxTest(unittest.TestCase):
 

--- a/tests/testCatalogs.py
+++ b/tests/testCatalogs.py
@@ -133,6 +133,7 @@ class InstanceCatalogTestCase(unittest.TestCase):
             os.unlink(cls.starTextName)
 
     def setUp(self):
+        self.scratch_dir = os.path.join(getPackageDir('sims_catalogs'), 'tests', 'scratchSpace')
         self.obsMd = ObservationMetaData(boundType = 'circle', pointingRA = 210.0, pointingDec = -60.0,
                                          boundLength=20.0, mjd=52000., bandpassName='r')
 
@@ -285,6 +286,34 @@ class InstanceCatalogTestCase(unittest.TestCase):
 
         if os.path.exists(catName):
             os.unlink(catName)
+
+    def test_iter_catalog(self):
+        """
+        Test that iter_catalog returns the same results as write_catalog
+        """
+
+        obs = ObservationMetaData(pointingRA=10.0, pointingDec=-20.0,
+                                  boundLength=50.0, boundType='circle')
+
+        cat = BasicCatalog(self.starDB, obs_metadata=obs)
+        cat_name = os.path.join(self.scratch_dir, 'iter_catalog_control.txt')
+        cat.write_catalog(cat_name)
+        with open(cat_name, 'r') as in_file:
+            in_lines = in_file.readlines()
+        self.assertGreater(len(in_lines), 1)
+        self.assertLess(len(in_lines), len(self.starControlData))
+
+        cat = BasicCatalog(self.starDB, obs_metadata=obs)
+        line_ct = 0
+        for line in cat.iter_catalog():
+            str_line = '%d, %.12f, %.12f, %.12f, %.12f, %.12f, %.12f, %.12f, %.12f\n' % \
+            (line[0], line[1], line[2], line[3], line[4], line[5], line[6], line[7], line[8])
+            self.assertIn(str_line, in_lines)
+            line_ct += 1
+        self.assertEqual(line_ct, len(in_lines)-1)
+
+        if os.path.exists(cat_name):
+            os.unlink(cat_name)
 
 
 class boundingBoxTest(unittest.TestCase):

--- a/tests/testFilteringCatalogs.py
+++ b/tests/testFilteringCatalogs.py
@@ -85,6 +85,26 @@ class InstanceCatalogTestCase(unittest.TestCase):
                 self.assertEqual(line,
                                  '%d, %d, %d, %d\n' % (ii, ii+1, ii+2, ii+3))
 
+        # test that iter_catalog returns the same result
+        cat = FilteredCat(self.db)
+        line_ct = 0
+        for line in cat.iter_catalog():
+            str_line = '%d, %d, %d, %d\n' % (line[0], line[1], line[2], line[3])
+            line_ct += 1
+            self.assertIn(str_line, input_lines)
+        self.assertEqual(line_ct, len(input_lines)-1)
+
+        # test that iter_catalog_chunks returns the same result
+        cat = FilteredCat(self.db)
+        line_ct = 0
+        for chunk, chunk_map in cat.iter_catalog_chunks(chunk_size=2):
+            for ix in range(len(chunk[0])):
+                str_line = '%d, %d, %d, %d\n' % \
+                (chunk[0][ix], chunk[1][ix], chunk[2][ix], chunk[3][ix])
+                line_ct += 1
+            self.assertIn(str_line, input_lines)
+        self.assertEqual(line_ct, len(input_lines)-1)
+
         if os.path.exists(cat_name):
             os.unlink(cat_name)
 
@@ -130,6 +150,26 @@ class InstanceCatalogTestCase(unittest.TestCase):
                 self.assertEqual(line,
                                  '%d, %d, %d, %d\n' % (ii, ip1, ip2, ip3))
 
+        # test that iter_catalog returns the same result
+        cat = FilteredCat2(self.db)
+        line_ct = 0
+        for line in cat.iter_catalog():
+            str_line = '%d, %d, %d, %d\n' % (line[0], line[1], line[2], line[3])
+            line_ct += 1
+            self.assertIn(str_line, input_lines)
+        self.assertEqual(line_ct, len(input_lines)-1)
+
+        # test that iter_catalog_chunks returns the same result
+        cat = FilteredCat2(self.db)
+        line_ct = 0
+        for chunk, chunk_map in cat.iter_catalog_chunks(chunk_size=2):
+            for ix in range(len(chunk[0])):
+                str_line = '%d, %d, %d, %d\n' % \
+                (chunk[0][ix], chunk[1][ix], chunk[2][ix], chunk[3][ix])
+                line_ct += 1
+            self.assertIn(str_line, input_lines)
+        self.assertEqual(line_ct, len(input_lines)-1)
+
         if os.path.exists(cat_name):
             os.unlink(cat_name)
 
@@ -173,6 +213,26 @@ class InstanceCatalogTestCase(unittest.TestCase):
                 self.assertEqual((ii+3) % 3, 0)
                 self.assertEqual(line,
                                  '%d, %d, %d, %d\n' % (ii, ip1, ip2, ip3))
+
+        # test that iter_catalog returns the same result
+        cat = FilteredCat3(self.db, cannot_be_null=['ip2t', 'ip3t'])
+        line_ct = 0
+        for line in cat.iter_catalog():
+            str_line = '%d, %d, %d, %d\n' % (line[0], line[1], line[2], line[3])
+            line_ct += 1
+            self.assertIn(str_line, input_lines)
+        self.assertEqual(line_ct, len(input_lines)-1)
+
+        # test that iter_catalog_chunks returns the same result
+        cat = FilteredCat3(self.db, cannot_be_null=['ip2t', 'ip3t'])
+        line_ct = 0
+        for chunk, chunk_map in cat.iter_catalog_chunks(chunk_size=2):
+            for ix in range(len(chunk[0])):
+                str_line = '%d, %d, %d, %d\n' % \
+                (chunk[0][ix], chunk[1][ix], chunk[2][ix], chunk[3][ix])
+                line_ct += 1
+            self.assertIn(str_line, input_lines)
+        self.assertEqual(line_ct, len(input_lines)-1)
 
         if os.path.exists(cat_name):
             os.unlink(cat_name)
@@ -219,6 +279,29 @@ class InstanceCatalogTestCase(unittest.TestCase):
                 self.assertEqual(line, '%d, %d, %d, %d, %.1f\n'
                                         % (ii, ip3*ip3, ip3*ip3*ip3, ip3*ip3*ip3*ip3, 0.5*(ip3*ip3)))
 
+
+        # test that iter_catalog returns the same result
+        cat = FilteredCat4(self.db)
+        line_ct = 0
+        for line in cat.iter_catalog():
+            str_line = '%d, %d, %d, %d, %.1f\n' % (line[0], line[1], line[2],
+                                                   line[3], line[4])
+            line_ct += 1
+            self.assertIn(str_line, input_lines)
+        self.assertEqual(line_ct, len(input_lines)-1)
+
+        # test that iter_catalog_chunks returns the same result
+        cat = FilteredCat4(self.db)
+        line_ct = 0
+        for chunk, chunk_map in cat.iter_catalog_chunks(chunk_size=2):
+            for ix in range(len(chunk[0])):
+                str_line = '%d, %d, %d, %d, %.1f\n' % \
+                (chunk[0][ix], chunk[1][ix], chunk[2][ix], chunk[3][ix],
+                 chunk[4][ix])
+                line_ct += 1
+            self.assertIn(str_line, input_lines)
+        self.assertEqual(line_ct, len(input_lines)-1)
+
         if os.path.exists(cat_name):
             os.unlink(cat_name)
 
@@ -260,6 +343,27 @@ class InstanceCatalogTestCase(unittest.TestCase):
                 self.assertEqual((ip3**4) % 3, 0)
                 self.assertEqual(line, '%d, %d, %d, %d\n'
                                         % (ii, ip3*ip3, ip3*ip3*ip3, ip3*ip3*ip3*ip3))
+
+        # test that iter_catalog returns the same result
+        cat = FilteredCat5(self.db)
+        line_ct = 0
+        for line in cat.iter_catalog():
+            str_line = '%d, %d, %d, %d\n' % (line[0], line[1], line[2], line[3])
+            line_ct += 1
+            self.assertIn(str_line, input_lines)
+        self.assertEqual(line_ct, len(input_lines)-1)
+
+        # test that iter_catalog_chunks returns the same result
+        cat = FilteredCat5(self.db)
+        line_ct = 0
+        for chunk, chunk_map in cat.iter_catalog_chunks(chunk_size=2):
+            for ix in range(len(chunk[0])):
+                str_line = '%d, %d, %d, %d\n' % \
+                (chunk[0][ix], chunk[1][ix], chunk[2][ix], chunk[3][ix])
+                line_ct += 1
+            self.assertIn(str_line, input_lines)
+        self.assertEqual(line_ct, len(input_lines)-1)
+
 
         if os.path.exists(cat_name):
             os.unlink(cat_name)
@@ -303,6 +407,27 @@ class InstanceCatalogTestCase(unittest.TestCase):
                 self.assertEqual(line, '%d, %d, %d\n'
                                         % (ii, ip3*ip3, ip3*ip3*ip3))
 
+        # test that iter_catalog returns the same result
+        cat = FilteredCat5b(self.db)
+        line_ct = 0
+        for line in cat.iter_catalog():
+            str_line = '%d, %d, %d\n' % (line[0], line[1], line[2])
+            line_ct += 1
+            self.assertIn(str_line, input_lines)
+        self.assertEqual(line_ct, len(input_lines)-1)
+
+        # test that iter_catalog_chunks returns the same result
+        cat = FilteredCat5b(self.db)
+        line_ct = 0
+        for chunk, chunk_map in cat.iter_catalog_chunks(chunk_size=2):
+            for ix in range(len(chunk[0])):
+                str_line = '%d, %d, %d\n' % \
+                (chunk[0][ix], chunk[1][ix], chunk[2][ix])
+                line_ct += 1
+            self.assertIn(str_line, input_lines)
+        self.assertEqual(line_ct, len(input_lines)-1)
+
+
         if os.path.exists(cat_name):
             os.unlink(cat_name)
 
@@ -341,6 +466,27 @@ class InstanceCatalogTestCase(unittest.TestCase):
                 self.assertGreater(ii+1, 5)
                 self.assertEqual(line, '%d, %d\n' % (ii, ii+1))
 
+        # test that iter_catalog returns the same result
+        cat = FilteredCat6(self.db)
+        line_ct = 0
+        for line in cat.iter_catalog():
+            str_line = '%d, %d\n' % (line[0], line[1])
+            line_ct += 1
+            self.assertIn(str_line, input_lines)
+        self.assertEqual(line_ct, len(input_lines)-1)
+
+        # test that iter_catalog_chunks returns the same result
+        cat = FilteredCat6(self.db)
+        line_ct = 0
+        for chunk, chunk_map in cat.iter_catalog_chunks(chunk_size=2):
+            for ix in range(len(chunk[0])):
+                str_line = '%d, %d\n' % \
+                (chunk[0][ix], chunk[1][ix])
+                line_ct += 1
+            self.assertIn(str_line, input_lines)
+        self.assertEqual(line_ct, len(input_lines)-1)
+
+
         if os.path.exists(cat_name):
             os.unlink(cat_name)
 
@@ -374,6 +520,27 @@ class InstanceCatalogTestCase(unittest.TestCase):
                 ii = i_line - 1
                 self.assertLess(ii+3, 7)
                 self.assertEqual(line, '%d, %d\n' % (ii, ii+1))
+
+        # test that iter_catalog returns the same result
+        cat = FilteredCat7(self.db)
+        line_ct = 0
+        for line in cat.iter_catalog():
+            str_line = '%d, %d\n' % (line[0], line[1])
+            line_ct += 1
+            self.assertIn(str_line, input_lines)
+        self.assertEqual(line_ct, len(input_lines)-1)
+
+        # test that iter_catalog_chunks returns the same result
+        cat = FilteredCat7(self.db)
+        line_ct = 0
+        for chunk, chunk_map in cat.iter_catalog_chunks(chunk_size=2):
+            for ix in range(len(chunk[0])):
+                str_line = '%d, %d\n' % \
+                (chunk[0][ix], chunk[1][ix])
+                line_ct += 1
+            self.assertIn(str_line, input_lines)
+        self.assertEqual(line_ct, len(input_lines)-1)
+
 
         if os.path.exists(cat_name):
             os.unlink(cat_name)
@@ -415,6 +582,27 @@ class InstanceCatalogTestCase(unittest.TestCase):
                 self.assertEqual((ii+2) % 2, 0)
                 self.assertGreater(ii+3, 8)
                 self.assertEqual(line, '%d, %d\n' % (ii, ii+1))
+
+        # test that iter_catalog returns the same result
+        cat = FilteredCat8(self.db, cannot_be_null=['filter2'])
+        line_ct = 0
+        for line in cat.iter_catalog():
+            str_line = '%d, %d\n' % (line[0], line[1])
+            line_ct += 1
+            self.assertIn(str_line, input_lines)
+        self.assertEqual(line_ct, len(input_lines)-1)
+
+        # test that iter_catalog_chunks returns the same result
+        cat = FilteredCat8(self.db, cannot_be_null=['filter2'])
+        line_ct = 0
+        for chunk, chunk_map in cat.iter_catalog_chunks(chunk_size=2):
+            for ix in range(len(chunk[0])):
+                str_line = '%d, %d\n' % \
+                (chunk[0][ix], chunk[1][ix])
+                line_ct += 1
+            self.assertIn(str_line, input_lines)
+        self.assertEqual(line_ct, len(input_lines)-1)
+
 
         if os.path.exists(cat_name):
             os.unlink(cat_name)


### PR DESCRIPTION
This PR just adds some functionality that I noticed was missing.  Namely, it makes `iter_catalog()` and `iter_catalog_chunks()` aware of `self._cannot_be_null`, so that you can filter an InstanceCatalog on columns without having to write it to disk. 