### PR TITLE
Sim 2414/detect dtype

### DIFF
--- a/tests/testCatalogDBObject.py
+++ b/tests/testCatalogDBObject.py
@@ -74,25 +74,29 @@ class myNonsenseFileDB(fileDBObject):
 class testCatalogDBObjectTestStars(myTestStars):
     objid = 'testCatalogDBObjectTeststars'
     driver = 'sqlite'
-    database = 'testCatalogDBObjectDatabase.db'
+    database = os.path.join(getPackageDir('sims_catalogs'), 'tests',
+                            'scratchSpace', 'testCatalogDBObjectDatabase.db')
 
 
 class testCatalogDBObjectTestGalaxies(myTestGals):
     objid = 'testCatalogDBObjectTestgals'
     driver = 'sqlite'
-    database = 'testCatalogDBObjectDatabase.db'
+    database = os.path.join(getPackageDir('sims_catalogs'), 'tests',
+                            'scratchSpace', 'testCatalogDBObjectDatabase.db')
 
 
 class CatalogDBObjectTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        cls.scratch_dir = os.path.join(getPackageDir('sims_catalogs'), 'tests', 'scratchSpace')
         # Delete the test database if it exists and start fresh.
-        if os.path.exists('testCatalogDBObjectDatabase.db'):
+        cls.dbo_db_name = os.path.join(cls.scratch_dir, 'testCatalogDBObjectDatabase.db')
+        if os.path.exists(cls.dbo_db_name):
             print("deleting database")
-            os.unlink('testCatalogDBObjectDatabase.db')
-        tu.makeStarTestDB(filename='testCatalogDBObjectDatabase.db', size=5000, seedVal=1)
-        tu.makeGalTestDB(filename='testCatalogDBObjectDatabase.db', size=5000, seedVal=1)
+            os.unlink(cls.dbo_db_name)
+        tu.makeStarTestDB(filename=cls.dbo_db_name, size=5000, seedVal=1)
+        tu.makeGalTestDB(filename=cls.dbo_db_name, size=5000, seedVal=1)
 
         #Create a database from generic data stored in testData/CatalogsGenerationTestData.txt
         #This will be used to make sure that circle and box spatial bounds yield the points
@@ -145,8 +149,8 @@ class CatalogDBObjectTestCase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         sims_clean_up()
-        if os.path.exists('testCatalogDBObjectDatabase.db'):
-            os.unlink('testCatalogDBObjectDatabase.db')
+        if os.path.exists(cls.dbo_db_name):
+            os.unlink(cls.dbo_db_name)
         if os.path.exists('testCatalogDBObjectNonsenseDB.db'):
             os.unlink('testCatalogDBObjectNonsenseDB.db')
 
@@ -471,7 +475,7 @@ class CatalogDBObjectTestCase(unittest.TestCase):
         self.assertEqual(mystars.decColName, 'decl')
         self.assertEqual(mystars.idColKey, 'id')
         self.assertEqual(mystars.driver, 'sqlite')
-        self.assertEqual(mystars.database, 'testCatalogDBObjectDatabase.db')
+        self.assertEqual(mystars.database, self.dbo_db_name)
         self.assertEqual(mystars.appendint, 1023)
         self.assertEqual(mystars.tableid, 'stars')
         self.assertFalse(hasattr(mystars, 'spatialModel'),
@@ -482,7 +486,7 @@ class CatalogDBObjectTestCase(unittest.TestCase):
         self.assertEqual(mygalaxies.decColName, 'decl')
         self.assertEqual(mygalaxies.idColKey, 'id')
         self.assertEqual(mygalaxies.driver, 'sqlite')
-        self.assertEqual(mygalaxies.database, 'testCatalogDBObjectDatabase.db')
+        self.assertEqual(mygalaxies.database, self.dbo_db_name)
         self.assertEqual(mygalaxies.appendint, 1022)
         self.assertEqual(mygalaxies.tableid, 'galaxies')
         self.assertTrue(hasattr(mygalaxies, 'spatialModel'),

--- a/tests/testCatalogDBObject.py
+++ b/tests/testCatalogDBObject.py
@@ -24,7 +24,8 @@ def setup_module(module):
 class dbForQueryColumnsTest(CatalogDBObject):
     objid = 'queryColumnsNonsense'
     tableid = 'queryColumnsTest'
-    database = 'testCatalogDBObjectNonsenseDB.db'
+    database = os.path.join(getPackageDir('sims_catalogs'), 'tests',
+                            'scratchSpace', 'testCatalogDBObjectNonsenseDB.db')
     idColKey = 'i1'
     dbDefaultValues = {'i2': -1, 'i3': -2}
 
@@ -34,7 +35,8 @@ class myNonsenseDB(CatalogDBObject):
     tableid = 'test'
     idColKey = 'NonsenseId'
     driver = 'sqlite'
-    database = 'testCatalogDBObjectNonsenseDB.db'
+    database = os.path.join(getPackageDir('sims_catalogs'), 'tests',
+                            'scratchSpace', 'testCatalogDBObjectNonsenseDB.db')
     raColName = 'ra'
     decColName = 'dec'
     columns = [('NonsenseId', 'id', int),
@@ -102,10 +104,11 @@ class CatalogDBObjectTestCase(unittest.TestCase):
         #This will be used to make sure that circle and box spatial bounds yield the points
         #they are supposed to.
         dataDir = os.path.join(getPackageDir('sims_catalogs'), 'tests', 'testData')
-        if os.path.exists('testCatalogDBObjectNonsenseDB.db'):
-            os.unlink('testCatalogDBObjectNonsenseDB.db')
+        cls.nonsense_db_name = os.path.join(cls.scratch_dir, 'testCatalogDBObjectNonsenseDB.db')
+        if os.path.exists(cls.nonsense_db_name):
+            os.unlink(cls.nonsense_db_name)
 
-        conn = sqlite3.connect('testCatalogDBObjectNonsenseDB.db')
+        conn = sqlite3.connect(cls.nonsense_db_name)
         c = conn.cursor()
         try:
             c.execute('''CREATE TABLE test (id int, ra real, dec real, mag real)''')
@@ -151,8 +154,8 @@ class CatalogDBObjectTestCase(unittest.TestCase):
         sims_clean_up()
         if os.path.exists(cls.dbo_db_name):
             os.unlink(cls.dbo_db_name)
-        if os.path.exists('testCatalogDBObjectNonsenseDB.db'):
-            os.unlink('testCatalogDBObjectNonsenseDB.db')
+        if os.path.exists(cls.nonsense_db_name):
+            os.unlink(cls.nonsense_db_name)
 
     def setUp(self):
         self.obsMd = ObservationMetaData(pointingRA=210.0, pointingDec=-60.0, boundLength=1.75,
@@ -498,7 +501,7 @@ class CatalogDBObjectTestCase(unittest.TestCase):
         self.assertEqual(myNonsense.decColName, 'dec')
         self.assertEqual(myNonsense.idColKey, 'NonsenseId')
         self.assertEqual(myNonsense.driver, 'sqlite')
-        self.assertEqual(myNonsense.database, 'testCatalogDBObjectNonsenseDB.db')
+        self.assertEqual(myNonsense.database, self.nonsense_db_name)
         self.assertFalse(hasattr(myNonsense, 'appendint'),
                          msg="myNonsense has attr 'appendint', which it should not")
         self.assertEqual(myNonsense.tableid, 'test')

--- a/tests/testCatalogDBObject.py
+++ b/tests/testCatalogDBObject.py
@@ -860,6 +860,34 @@ class CatalogDBObjectTestCase(unittest.TestCase):
                 ct += 1
         self.assertGreater(ct, 0)
 
+    def test_dtype_detection(self):
+        """
+        Test that, if we execute different queries on the same CatalogDBObject,
+        the dtype is correctly detected
+        """
+        db = testCatalogDBObjectTestStars()
+        results = db.query_columns(colnames=['ra', 'id', 'varParamStr'], chunk_size=1000)
+        n_chunks = 0
+        for chunk in results:
+            n_chunks += 1
+            self.assertGreater(len(chunk), 0)
+            self.assertEqual(str(chunk.dtype['ra']), 'float64')
+            self.assertEqual(str(chunk.dtype['id']), 'int64')
+            self.assertEqual(str(chunk.dtype['varParamStr']), '|S256')
+            self.assertEqual(len(chunk.dtype.names), 3)
+        self.assertGreater(n_chunks, 0)
+
+        results = db.query_columns(colnames=['ra', 'id', 'ebv'], chunk_size=1000)
+        n_chunks = 0
+        for chunk in results:
+            n_chunks += 1
+            self.assertGreater(len(chunk), 0)
+            self.assertEqual(str(chunk.dtype['ra']), 'float64')
+            self.assertEqual(str(chunk.dtype['id']), 'int64')
+            self.assertEqual(str(chunk.dtype['ebv']), 'float64')
+            self.assertEqual(len(chunk.dtype.names), 3)
+        self.assertGreater(n_chunks, 0)
+
 
 class fileDBObjectTestCase(unittest.TestCase):
     """

--- a/tests/testCatalogDBObject.py
+++ b/tests/testCatalogDBObject.py
@@ -21,58 +21,6 @@ def setup_module(module):
     lsst.utils.tests.init()
 
 
-def createNonsenseDB():
-    """
-    Create a database from generic data store in testData/CatalogsGenerationTestData.txt
-    This will be used to make sure that circle and box spatial bounds yield the points
-    they are supposed to.
-    """
-    dataDir = os.path.join(getPackageDir('sims_catalogs'), 'tests', 'testData')
-    if os.path.exists('testCatalogDBObjectNonsenseDB.db'):
-        os.unlink('testCatalogDBObjectNonsenseDB.db')
-
-    conn = sqlite3.connect('testCatalogDBObjectNonsenseDB.db')
-    c = conn.cursor()
-    try:
-        c.execute('''CREATE TABLE test (id int, ra real, dec real, mag real)''')
-        conn.commit()
-    except:
-        raise RuntimeError("Error creating database table test.")
-
-    try:
-        c.execute('''CREATE TABLE test2 (id int, mag real)''')
-        conn.commit()
-    except:
-        raise RuntimeError("Error creating database table test2.")
-
-    with open(os.path.join(dataDir, 'CatalogsGenerationTestData.txt'), 'r') as inFile:
-        for line in inFile:
-            values = line.split()
-            cmd = '''INSERT INTO test VALUES (%s, %s, %s, %s)''' % \
-                  (values[0], values[1], values[2], values[3])
-            c.execute(cmd)
-            if int(values[0])%2 == 0:
-                cmd = '''INSERT INTO test2 VALUES (%s, %s)''' % (values[0], str(2.0*float(values[3])))
-                c.execute(cmd)
-
-        conn.commit()
-
-    try:
-        c.execute('''CREATE TABLE queryColumnsTest (i1 int, i2 int, i3 int)''')
-        conn.commit()
-    except:
-        raise RuntimeError("Error creating database table queryColumnsTest.")
-
-    with open(os.path.join(dataDir, 'QueryColumnsTestData.txt'), 'r') as inputFile:
-        for line in inputFile:
-            vv = line.split()
-            cmd = '''INSERT INTO queryColumnsTest VALUES (%s, %s, %s)''' % (vv[0], vv[1], vv[2])
-            c.execute(cmd)
-
-    conn.commit()
-    conn.close()
-
-
 class dbForQueryColumnsTest(CatalogDBObject):
     objid = 'queryColumnsNonsense'
     tableid = 'queryColumnsTest'
@@ -145,7 +93,54 @@ class CatalogDBObjectTestCase(unittest.TestCase):
             os.unlink('testCatalogDBObjectDatabase.db')
         tu.makeStarTestDB(filename='testCatalogDBObjectDatabase.db', size=5000, seedVal=1)
         tu.makeGalTestDB(filename='testCatalogDBObjectDatabase.db', size=5000, seedVal=1)
-        createNonsenseDB()
+
+        #Create a database from generic data stored in testData/CatalogsGenerationTestData.txt
+        #This will be used to make sure that circle and box spatial bounds yield the points
+        #they are supposed to.
+        dataDir = os.path.join(getPackageDir('sims_catalogs'), 'tests', 'testData')
+        if os.path.exists('testCatalogDBObjectNonsenseDB.db'):
+            os.unlink('testCatalogDBObjectNonsenseDB.db')
+
+        conn = sqlite3.connect('testCatalogDBObjectNonsenseDB.db')
+        c = conn.cursor()
+        try:
+            c.execute('''CREATE TABLE test (id int, ra real, dec real, mag real)''')
+            conn.commit()
+        except:
+            raise RuntimeError("Error creating database table test.")
+
+        try:
+            c.execute('''CREATE TABLE test2 (id int, mag real)''')
+            conn.commit()
+        except:
+            raise RuntimeError("Error creating database table test2.")
+
+        with open(os.path.join(dataDir, 'CatalogsGenerationTestData.txt'), 'r') as inFile:
+            for line in inFile:
+                values = line.split()
+                cmd = '''INSERT INTO test VALUES (%s, %s, %s, %s)''' % \
+                      (values[0], values[1], values[2], values[3])
+                c.execute(cmd)
+                if int(values[0])%2 == 0:
+                    cmd = '''INSERT INTO test2 VALUES (%s, %s)''' % (values[0], str(2.0*float(values[3])))
+                    c.execute(cmd)
+
+            conn.commit()
+
+        try:
+            c.execute('''CREATE TABLE queryColumnsTest (i1 int, i2 int, i3 int)''')
+            conn.commit()
+        except:
+            raise RuntimeError("Error creating database table queryColumnsTest.")
+
+        with open(os.path.join(dataDir, 'QueryColumnsTestData.txt'), 'r') as inputFile:
+            for line in inputFile:
+                vv = line.split()
+                cmd = '''INSERT INTO queryColumnsTest VALUES (%s, %s, %s)''' % (vv[0], vv[1], vv[2])
+                c.execute(cmd)
+
+        conn.commit()
+        conn.close()
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/testCatalogDBObject.py
+++ b/tests/testCatalogDBObject.py
@@ -4,6 +4,7 @@ from builtins import zip
 from builtins import str
 import os
 import sqlite3
+import sys
 
 import unittest
 import numpy as np
@@ -873,7 +874,10 @@ class CatalogDBObjectTestCase(unittest.TestCase):
             self.assertGreater(len(chunk), 0)
             self.assertEqual(str(chunk.dtype['ra']), 'float64')
             self.assertEqual(str(chunk.dtype['id']), 'int64')
-            self.assertEqual(str(chunk.dtype['varParamStr']), '|S256')
+            if sys.version_info.major == 2:
+                self.assertEqual(str(chunk.dtype['varParamStr']), '|S256')
+            else:
+                self.assertEqual(str(chunk.dtype['varParamStr']), '<U256')
             self.assertEqual(len(chunk.dtype.names), 3)
         self.assertGreater(n_chunks, 0)
 
@@ -900,7 +904,10 @@ class CatalogDBObjectTestCase(unittest.TestCase):
         # because, with execute_arbitrary(), the dtype detects the
         # exact length of the string.  With query_columns() it uses
         # a value that is encoded in CatalogDBObject
-        self.assertEqual(str(results.dtype['varParamStr']), '|S102')
+        if sys.version_info.major == 2:
+            self.assertEqual(str(results.dtype['varParamStr']), '|S102')
+        else:
+            self.assertEqual(str(results.dtype['varParamStr']), '<U101')
         self.assertEqual(str(results.dtype['umag']), 'float64')
         self.assertEqual(len(results.dtype.names), 4)
 

--- a/tests/testDBObject.py
+++ b/tests/testDBObject.py
@@ -366,6 +366,7 @@ class DBObjectTestCase(unittest.TestCase):
         self.assertEqual(str(results.dtype['id']), 'int64')
         self.assertEqual(str(results.dtype['val']), 'float64')
         self.assertEqual(str(results.dtype['sentence']), '|S22')
+        self.assertEqual(len(results.dtype), 3)
 
         # now test that it works when getting a ChunkIterator
         chunk_iter = db.get_arbitrary_chunk_iterator(query, chunk_size=3)
@@ -375,6 +376,7 @@ class DBObjectTestCase(unittest.TestCase):
             self.assertEqual(str(chunk.dtype['id']), 'int64')
             self.assertEqual(str(chunk.dtype['val']), 'float64')
             self.assertEqual(str(chunk.dtype['sentence']), '|S22')
+            self.assertEqual(len(chunk.dtype), 3)
 
             for line in chunk:
                 ct += 1

--- a/tests/testDBObject.py
+++ b/tests/testDBObject.py
@@ -2,6 +2,7 @@ from builtins import next
 from builtins import range
 import os
 import sqlite3
+import sys
 
 import numpy as np
 import unittest
@@ -365,7 +366,10 @@ class DBObjectTestCase(unittest.TestCase):
 
         self.assertEqual(str(results.dtype['id']), 'int64')
         self.assertEqual(str(results.dtype['val']), 'float64')
-        self.assertEqual(str(results.dtype['sentence']), '|S22')
+        if sys.version_info.major == 2:
+            self.assertEqual(str(results.dtype['sentence']), '|S22')
+        else:
+            self.assertEqual(str(results.dtype['sentence']), '<U22')
         self.assertEqual(len(results.dtype), 3)
 
         # now test that it works when getting a ChunkIterator
@@ -375,7 +379,10 @@ class DBObjectTestCase(unittest.TestCase):
 
             self.assertEqual(str(chunk.dtype['id']), 'int64')
             self.assertEqual(str(chunk.dtype['val']), 'float64')
-            self.assertEqual(str(chunk.dtype['sentence']), '|S22')
+            if sys.version_info.major == 2:
+                self.assertEqual(str(results.dtype['sentence']), '|S22')
+            else:
+                self.assertEqual(str(results.dtype['sentence']), '<U22')
             self.assertEqual(len(chunk.dtype), 3)
 
             for line in chunk:
@@ -392,7 +399,10 @@ class DBObjectTestCase(unittest.TestCase):
         self.assertGreater(len(results), 0)
         self.assertEqual(len(results.dtype.names), 2)
         self.assertEqual(str(results.dtype['id']), 'int64')
-        self.assertEqual(str(results.dtype['sentence']), '|S22')
+        if sys.version_info.major == 2:
+            self.assertEqual(str(results.dtype['sentence']), '|S22')
+        else:
+            self.assertEqual(str(results.dtype['sentence']), '<U22')
 
         query = 'SELECT id, val, sentence FROM testTable WHERE id%2 = 0'
         chunk_iter = db.get_arbitrary_chunk_iterator(query, chunk_size=3)
@@ -401,7 +411,10 @@ class DBObjectTestCase(unittest.TestCase):
 
             self.assertEqual(str(chunk.dtype['id']), 'int64')
             self.assertEqual(str(chunk.dtype['val']), 'float64')
-            self.assertEqual(str(chunk.dtype['sentence']), '|S22')
+            if sys.version_info.major == 2:
+                self.assertEqual(str(results.dtype['sentence']), '|S22')
+            else:
+                self.assertEqual(str(results.dtype['sentence']), '<U22')
             self.assertEqual(len(chunk.dtype), 3)
 
             for line in chunk:

--- a/tests/testDBObject.py
+++ b/tests/testDBObject.py
@@ -7,6 +7,7 @@ import numpy as np
 import unittest
 import warnings
 import lsst.utils.tests
+from lsst.utils import getPackageDir
 from lsst.sims.catalogs.db import DBObject
 
 
@@ -14,87 +15,80 @@ def setup_module(module):
     lsst.utils.tests.init()
 
 
-def createDB():
-    """
-    Create a database with two tables of meaningless data to make sure that JOIN queries
-    can be executed using DBObject
-    """
-    if os.path.exists('testDBObjectDB.db'):
-        os.unlink('testDBObjectDB.db')
-
-    conn = sqlite3.connect('testDBObjectDB.db')
-    c = conn.cursor()
-    try:
-        c.execute('''CREATE TABLE intTable (id int, twice int, thrice int)''')
-        conn.commit()
-    except:
-        raise RuntimeError("Error creating database.")
-
-    for ii in range(100):
-        ll = 2*ii
-        jj = 2*ll
-        kk = 3*ll
-        cmd = '''INSERT INTO intTable VALUES (%s, %s, %s)''' % (ll, jj, kk)
-        c.execute(cmd)
-
-    conn.commit()
-
-    c = conn.cursor()
-    try:
-        c.execute('''CREATE TABLE doubleTable (id int, sqrt float, log float)''')
-        conn.commit()
-    except:
-        raise RuntimeError("Error creating database (double).")
-    for ii in range(200):
-        ll = ii + 1
-        nn = np.sqrt(float(ll))
-        mm = np.log(float(ll))
-
-        cmd = '''INSERT INTO doubleTable VALUES (%s, %s, %s)''' % (ll, nn, mm)
-        c.execute(cmd)
-    conn.commit()
-
-    try:
-        c.execute('''CREATE TABLE junkTable (id int, sqrt float, log float)''')
-        conn.commit()
-    except:
-        raise RuntimeError("Error creating database (double).")
-    for ii in range(200):
-        ll = ii + 1
-        nn = np.sqrt(float(ll))
-        mm = np.log(float(ll))
-
-        cmd = '''INSERT INTO junkTable VALUES (%s, %s, %s)''' % (ll, nn, mm)
-        c.execute(cmd)
-
-    conn.commit()
-    conn.close()
-
-
 class DBObjectTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        createDB()
+        """
+        Create a database with two tables of meaningless data to make sure that JOIN queries
+        can be executed using DBObject
+        """
+        scratch_dir = os.path.join(getPackageDir('sims_catalogs'), 'tests', 'scratchSpace')
+        cls.db_name = os.path.join(scratch_dir, 'testDBObjectDB.db')
+        if os.path.exists(cls.db_name):
+            os.unlink(cls.db_name)
+
+        conn = sqlite3.connect(cls.db_name)
+        c = conn.cursor()
+        try:
+            c.execute('''CREATE TABLE intTable (id int, twice int, thrice int)''')
+            conn.commit()
+        except:
+            raise RuntimeError("Error creating database.")
+
+        for ii in range(100):
+            ll = 2*ii
+            jj = 2*ll
+            kk = 3*ll
+            cmd = '''INSERT INTO intTable VALUES (%s, %s, %s)''' % (ll, jj, kk)
+            c.execute(cmd)
+
+        conn.commit()
+
+        c = conn.cursor()
+        try:
+            c.execute('''CREATE TABLE doubleTable (id int, sqrt float, log float)''')
+            conn.commit()
+        except:
+            raise RuntimeError("Error creating database (double).")
+        for ii in range(200):
+            ll = ii + 1
+            nn = np.sqrt(float(ll))
+            mm = np.log(float(ll))
+
+            cmd = '''INSERT INTO doubleTable VALUES (%s, %s, %s)''' % (ll, nn, mm)
+            c.execute(cmd)
+        conn.commit()
+
+        try:
+            c.execute('''CREATE TABLE junkTable (id int, sqrt float, log float)''')
+            conn.commit()
+        except:
+            raise RuntimeError("Error creating database (double).")
+        for ii in range(200):
+            ll = ii + 1
+            nn = np.sqrt(float(ll))
+            mm = np.log(float(ll))
+
+            cmd = '''INSERT INTO junkTable VALUES (%s, %s, %s)''' % (ll, nn, mm)
+            c.execute(cmd)
+
+        conn.commit()
+        conn.close()
 
     @classmethod
     def tearDownClass(cls):
-        if os.path.exists('testDBObjectDB.db'):
-            os.unlink('testDBObjectDB.db')
+        if os.path.exists(cls.db_name):
+            os.unlink(cls.db_name)
 
     def setUp(self):
         self.driver = 'sqlite'
-        self.database = 'testDBObjectDB.db'
-
-    def tearDown(self):
-        self.driver = 'sqlite'
-        self.database = 'testDBObjectDB.db'
 
     def testTableNames(self):
         """
         Test the method that returns the names of tables in a database
         """
-        dbobj = DBObject(driver=self.driver, database=self.database)
+        dbobj = DBObject(driver=self.driver, database=self.db_name)
         names = dbobj.get_table_names()
         self.assertEqual(len(names), 3)
         self.assertIn('doubleTable', names)
@@ -105,7 +99,7 @@ class DBObjectTestCase(unittest.TestCase):
         Test that the filters we placed on queries made with execute_aribtrary()
         work
         """
-        dbobj = DBObject(driver=self.driver, database=self.database)
+        dbobj = DBObject(driver=self.driver, database=self.db_name)
         controlQuery = 'SELECT doubleTable.id, intTable.id, doubleTable.log, intTable.thrice '
         controlQuery += 'FROM doubleTable, intTable WHERE doubleTable.id = intTable.id'
         dbobj.execute_arbitrary(controlQuery)
@@ -151,7 +145,7 @@ class DBObjectTestCase(unittest.TestCase):
         """
         Test the method that returns the names of columns in a table
         """
-        dbobj = DBObject(driver=self.driver, database=self.database)
+        dbobj = DBObject(driver=self.driver, database=self.db_name)
         names = dbobj.get_column_names('doubleTable')
         self.assertEqual(len(names), 3)
         self.assertIn('id', names)
@@ -182,7 +176,7 @@ class DBObjectTestCase(unittest.TestCase):
         """
         Test a query on a single table (using chunk iterator)
         """
-        dbobj = DBObject(driver=self.driver, database=self.database)
+        dbobj = DBObject(driver=self.driver, database=self.db_name)
         query = 'SELECT id, sqrt FROM doubleTable'
         results = dbobj.get_chunk_iterator(query)
 
@@ -205,7 +199,7 @@ class DBObjectTestCase(unittest.TestCase):
 
         (also test q query on a single table using .execute_arbitrary() directly
         """
-        dbobj = DBObject(driver=self.driver, database=self.database)
+        dbobj = DBObject(driver=self.driver, database=self.db_name)
         query = 'SELECT id, log FROM doubleTable'
         dtype = [('id', int), ('log', float)]
         results = dbobj.execute_arbitrary(query, dtype = dtype)
@@ -225,7 +219,7 @@ class DBObjectTestCase(unittest.TestCase):
         """
         Test a join
         """
-        dbobj = DBObject(driver=self.driver, database=self.database)
+        dbobj = DBObject(driver=self.driver, database=self.db_name)
         query = 'SELECT doubleTable.id, intTable.id, doubleTable.log, intTable.thrice '
         query += 'FROM doubleTable, intTable WHERE doubleTable.id = intTable.id'
         results = dbobj.get_chunk_iterator(query, chunk_size=10)
@@ -266,7 +260,7 @@ class DBObjectTestCase(unittest.TestCase):
         """
         Test queries on SQL functions by using the MIN and MAX functions
         """
-        dbobj = DBObject(driver=self.driver, database=self.database)
+        dbobj = DBObject(driver=self.driver, database=self.db_name)
         query = 'SELECT MAX(thrice), MIN(thrice) FROM intTable'
         results = dbobj.execute_arbitrary(query)
         self.assertEqual(results[0][0], 594)
@@ -280,7 +274,7 @@ class DBObjectTestCase(unittest.TestCase):
         Repeat the test from testJoin, but with a DBObject whose connection was passed
         directly from another DBObject, to make sure that passing a connection works
         """
-        dbobj_base = DBObject(driver=self.driver, database=self.database)
+        dbobj_base = DBObject(driver=self.driver, database=self.db_name)
         dbobj = DBObject(connection=dbobj_base.connection)
         query = 'SELECT doubleTable.id, intTable.id, doubleTable.log, intTable.thrice '
         query += 'FROM doubleTable, intTable WHERE doubleTable.id = intTable.id'
@@ -324,13 +318,13 @@ class DBObjectTestCase(unittest.TestCase):
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            DBObject('sqlite:///' + self.database)
+            DBObject('sqlite:///' + self.db_name)
             assert len(w) == 1
 
         # missing database
         self.assertRaises(AttributeError, DBObject, driver=self.driver)
         # missing driver
-        self.assertRaises(AttributeError, DBObject, database=self.database)
+        self.assertRaises(AttributeError, DBObject, database=self.db_name)
         # missing host
         self.assertRaises(AttributeError, DBObject, driver='mssql+pymssql')
         # missing port

--- a/tests/testDBObject.py
+++ b/tests/testDBObject.py
@@ -367,6 +367,23 @@ class DBObjectTestCase(unittest.TestCase):
         self.assertEqual(str(results.dtype['val']), 'float64')
         self.assertEqual(str(results.dtype['sentence']), '|S22')
 
+        # now test that it works when getting a ChunkIterator
+        chunk_iter = db.get_arbitrary_chunk_iterator(query, chunk_size=3)
+        ct = 0
+        for chunk in chunk_iter:
+
+            self.assertEqual(str(chunk.dtype['id']), 'int64')
+            self.assertEqual(str(chunk.dtype['val']), 'float64')
+            self.assertEqual(str(chunk.dtype['sentence']), '|S22')
+
+            for line in chunk:
+                ct += 1
+                self.assertEqual(line['sentence'], 'this, has; punctuation')
+                self.assertAlmostEqual(line['val'], line['id']*5.234, 5)
+                self.assertEqual(line['id']%2, 0)
+
+        self.assertEqual(ct, 5)
+
         if os.path.exists(db_name):
             os.unlink(db_name)
 

--- a/tests/testParallelCatalogWriter.py
+++ b/tests/testParallelCatalogWriter.py
@@ -170,6 +170,10 @@ class ParallelWriterTestCase(unittest.TestCase):
         self.assertEqual(ct_in_3, len(data3['id']))
         self.assertEqual(ct, 100)
 
+        for file_name in class_dict:
+            if os.path.exists(file_name):
+                os.unlink(file_name)
+
     def test_parallel_writing_chunk_size(self):
         """
         Test that parallelCatalogWriter gets the right columns in it
@@ -243,6 +247,10 @@ class ParallelWriterTestCase(unittest.TestCase):
         self.assertEqual(ct_in_2, len(data2['id']))
         self.assertEqual(ct_in_3, len(data3['id']))
         self.assertEqual(ct, 100)
+
+        for file_name in class_dict:
+            if os.path.exists(file_name):
+                os.unlink(file_name)
 
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
This should fix the problem with DBObject.execute_arbitrary() failing to detect the data type of columns with commas in them.

I also took the opportunity to clean up some of the affected unit test files.