### PR TITLE
SIM-2422: Rewrite tests to use temporary scratch space

### DIFF
--- a/tests/testCatalogDBObject.py
+++ b/tests/testCatalogDBObject.py
@@ -1309,5 +1309,5 @@ class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
 
 if __name__ == "__main__":
     setup_module(None)
-    unittest.main()
+    unittest.main(exit=False)
     teardown_module(None)

--- a/tests/testCatalogDBObject.py
+++ b/tests/testCatalogDBObject.py
@@ -2,14 +2,16 @@ from __future__ import with_statement
 from __future__ import print_function
 from builtins import zip
 from builtins import str
+from builtins import super
 import os
 import sqlite3
 import sys
 
 import unittest
 import numpy as np
+import tempfile
+import shutil
 import lsst.utils.tests
-from lsst.utils import getPackageDir
 from lsst.sims.utils.CodeUtilities import sims_clean_up
 from lsst.sims.utils import ObservationMetaData
 from lsst.sims.catalogs.db import CatalogDBObject, fileDBObject
@@ -17,18 +19,31 @@ import lsst.sims.catalogs.utils.testUtils as tu
 from lsst.sims.catalogs.utils.testUtils import myTestStars, myTestGals
 from lsst.sims.utils import haversine
 
+ROOT = os.path.abspath(os.path.dirname(__file__))
+SCRATCH_DIR = None
+
 
 def setup_module(module):
+    global SCRATCH_DIR
     lsst.utils.tests.init()
+    SCRATCH_DIR = tempfile.mkdtemp(dir=ROOT, prefix="scratchSpace-")
+
+
+def teardown_module(module):
+    global SCRATCH_DIR
+    if os.path.exists(SCRATCH_DIR):
+        shutil.rmtree(SCRATCH_DIR)
 
 
 class dbForQueryColumnsTest(CatalogDBObject):
     objid = 'queryColumnsNonsense'
     tableid = 'queryColumnsTest'
-    database = os.path.join(getPackageDir('sims_catalogs'), 'tests',
-                            'scratchSpace', 'testCatalogDBObjectNonsenseDB.db')
     idColKey = 'i1'
     dbDefaultValues = {'i2': -1, 'i3': -2}
+
+    def __init__(self, **kwargs):
+        db = os.path.join(SCRATCH_DIR, 'testCatalogDBObjectNonsenseDB.db')
+        super().__init__(database=db, **kwargs)
 
 
 class myNonsenseDB(CatalogDBObject):
@@ -36,14 +51,16 @@ class myNonsenseDB(CatalogDBObject):
     tableid = 'test'
     idColKey = 'NonsenseId'
     driver = 'sqlite'
-    database = os.path.join(getPackageDir('sims_catalogs'), 'tests',
-                            'scratchSpace', 'testCatalogDBObjectNonsenseDB.db')
     raColName = 'ra'
     decColName = 'dec'
     columns = [('NonsenseId', 'id', int),
                ('NonsenseRaJ2000', 'ra*%f'%(np.pi/180.)),
                ('NonsenseDecJ2000', 'dec*%f'%(np.pi/180.)),
                ('NonsenseMag', 'mag', float)]
+
+    def __init__(self, **kwargs):
+        db = os.path.join(SCRATCH_DIR, 'testCatalogDBObjectNonsenseDB.db')
+        super().__init__(database=db, **kwargs)
 
 
 class myNonsenseDB_noConnection(CatalogDBObject):
@@ -77,22 +94,26 @@ class myNonsenseFileDB(fileDBObject):
 class testCatalogDBObjectTestStars(myTestStars):
     objid = 'testCatalogDBObjectTeststars'
     driver = 'sqlite'
-    database = os.path.join(getPackageDir('sims_catalogs'), 'tests',
-                            'scratchSpace', 'testCatalogDBObjectDatabase.db')
+
+    def __init__(self, **kwargs):
+        db = os.path.join(SCRATCH_DIR, 'testCatalogDBObjectDatabase.db')
+        super().__init__(database=db, **kwargs)
 
 
 class testCatalogDBObjectTestGalaxies(myTestGals):
     objid = 'testCatalogDBObjectTestgals'
     driver = 'sqlite'
-    database = os.path.join(getPackageDir('sims_catalogs'), 'tests',
-                            'scratchSpace', 'testCatalogDBObjectDatabase.db')
+
+    def __init__(self, **kwargs):
+        db = os.path.join(SCRATCH_DIR, 'testCatalogDBObjectDatabase.db')
+        super().__init__(database=db, **kwargs)
 
 
 class CatalogDBObjectTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.scratch_dir = os.path.join(getPackageDir('sims_catalogs'), 'tests', 'scratchSpace')
+        cls.scratch_dir = SCRATCH_DIR
         # Delete the test database if it exists and start fresh.
         cls.dbo_db_name = os.path.join(cls.scratch_dir, 'testCatalogDBObjectDatabase.db')
         if os.path.exists(cls.dbo_db_name):
@@ -104,7 +125,7 @@ class CatalogDBObjectTestCase(unittest.TestCase):
         #Create a database from generic data stored in testData/CatalogsGenerationTestData.txt
         #This will be used to make sure that circle and box spatial bounds yield the points
         #they are supposed to.
-        dataDir = os.path.join(getPackageDir('sims_catalogs'), 'tests', 'testData')
+        dataDir = os.path.join(ROOT, 'testData')
         cls.nonsense_db_name = os.path.join(cls.scratch_dir, 'testCatalogDBObjectNonsenseDB.db')
         if os.path.exists(cls.nonsense_db_name):
             os.unlink(cls.nonsense_db_name)
@@ -162,7 +183,7 @@ class CatalogDBObjectTestCase(unittest.TestCase):
         self.obsMd = ObservationMetaData(pointingRA=210.0, pointingDec=-60.0, boundLength=1.75,
                                          boundType='circle', mjd=52000., bandpassName='r')
 
-        self.filepath = os.path.join(getPackageDir('sims_catalogs'), 'tests',
+        self.filepath = os.path.join(ROOT,
                                      'testData', 'CatalogsGenerationTestData.txt')
 
         """
@@ -561,6 +582,7 @@ class CatalogDBObjectTestCase(unittest.TestCase):
         """
         Test that dbDefaultValues get properly applied when query_columns is called
         """
+
         db = dbForQueryColumnsTest(driver='sqlite')
         colnames = ['i1', 'i2', 'i3']
         results = db.query_columns(colnames)
@@ -964,9 +986,9 @@ class fileDBObjectTestCase(unittest.TestCase):
 
     def setUp(self):
         self.testDataFile = os.path.join(
-            getPackageDir('sims_catalogs'), 'tests', 'testData', 'CatalogsGenerationTestData.txt')
+            ROOT, 'testData', 'CatalogsGenerationTestData.txt')
         self.testHeaderFile = os.path.join(
-            getPackageDir('sims_catalogs'), 'tests', 'testData', 'CatalogsGenerationTestDataHeader.txt')
+            ROOT, 'testData', 'CatalogsGenerationTestDataHeader.txt')
 
         self.myNonsense = fileDBObject.from_objid('fileNonsense', self.testDataFile,
                                                   dtype = np.dtype([('id', int), ('ra', float),
@@ -1284,6 +1306,8 @@ class fileDBObjectTestCase(unittest.TestCase):
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
     pass
 
+
 if __name__ == "__main__":
-    lsst.utils.tests.init()
+    setup_module(None)
     unittest.main()
+    teardown_module(None)

--- a/tests/testCatalogs.py
+++ b/tests/testCatalogs.py
@@ -4,13 +4,17 @@ from builtins import object
 import os
 import numpy as np
 import unittest
-from lsst.utils import getPackageDir
+import tempfile
+import shutil
 import lsst.utils.tests
 from lsst.sims.utils import ObservationMetaData
 from lsst.sims.catalogs.db import fileDBObject
 from lsst.sims.catalogs.definitions import InstanceCatalog
 from lsst.sims.catalogs.decorators import compound
 from lsst.sims.utils import haversine
+
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 def setup_module(module):
@@ -118,8 +122,8 @@ class InstanceCatalogTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
 
-        cls.starTextName = os.path.join(getPackageDir('sims_catalogs'), 'tests',
-                                        'scratchSpace', 'icStarTestCatalog.txt')
+        cls.scratch_dir = tempfile.mkdtemp(dir=ROOT, prefix="scratchSpace-")
+        cls.starTextName = os.path.join(cls.scratch_dir, 'icStarTestCatalog.txt')
 
         if os.path.exists(cls.starTextName):
             os.unlink(cls.starTextName)
@@ -131,9 +135,10 @@ class InstanceCatalogTestCase(unittest.TestCase):
 
         if os.path.exists(cls.starTextName):
             os.unlink(cls.starTextName)
+        if os.path.exists(cls.scratch_dir):
+                shutil.rmtree(cls.scratch_dir)
 
     def setUp(self):
-        self.scratch_dir = os.path.join(getPackageDir('sims_catalogs'), 'tests', 'scratchSpace')
         self.obsMd = ObservationMetaData(boundType = 'circle', pointingRA = 210.0, pointingDec = -60.0,
                                          boundLength=20.0, mjd=52000., bandpassName='r')
 
@@ -144,7 +149,7 @@ class InstanceCatalogTestCase(unittest.TestCase):
         outside of the pointing
         """
 
-        catName = os.path.join(getPackageDir('sims_catalogs'), 'tests', 'scratchSpace', '_starLikeCat.txt')
+        catName = os.path.join(self.scratch_dir, '_starLikeCat.txt')
 
         if os.path.exists(catName):
             os.unlink(catName)
@@ -264,7 +269,7 @@ class InstanceCatalogTestCase(unittest.TestCase):
         """
         Test that transformations are applied to columns in an InstanceCatalog
         """
-        catName = os.path.join(getPackageDir('sims_catalogs'), 'tests', 'scratchSpace',
+        catName = os.path.join(self.scratch_dir,
                                'transformation_catalog.txt')
 
         if os.path.exists(catName):
@@ -353,7 +358,8 @@ class boundingBoxTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.starTextName = os.path.join(getPackageDir('sims_catalogs'), 'tests', 'scratchSpace',
+        cls.scratch_dir = tempfile.mkdtemp(dir=ROOT, prefix="scratchSpace-")
+        cls.starTextName = os.path.join(cls.scratch_dir,
                                         'bbStarTestCatalog.txt')
 
         cls.starDB, cls.starControlData = write_star_file_db(cls.starTextName)
@@ -362,6 +368,8 @@ class boundingBoxTest(unittest.TestCase):
     def tearDownClass(cls):
         if os.path.exists(cls.starTextName):
             os.unlink(cls.starTextName)
+        if os.path.exists(cls.scratch_dir):
+            shutil.rmtree(cls.scratch_dir)
 
     def setUp(self):
 
@@ -391,8 +399,7 @@ class boundingBoxTest(unittest.TestCase):
         does not admit any objects outside of the bounding box
         """
 
-        catName = os.path.join(getPackageDir('sims_catalogs'), 'tests',
-                               'scratchSpace', 'box_test_catalog.txt')
+        catName = os.path.join(self.scratch_dir, 'box_test_catalog.txt')
 
         myCatalog = self.starDB.getCatalog('bounds_catalog', obs_metadata = self.obsMdBox)
 
@@ -445,7 +452,7 @@ class boundingBoxTest(unittest.TestCase):
         does not admit any objects outside of the bounding circle
         """
 
-        catName = os.path.join(getPackageDir('sims_catalogs'), 'tests', 'scratchSpace',
+        catName = os.path.join(self.scratch_dir,
                                'circular_test_catalog.txt')
 
         if os.path.exists(catName):

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -4,12 +4,15 @@ from builtins import range
 import unittest
 import numpy
 import os
+import tempfile
+import shutil
 import lsst.utils.tests
-from lsst.utils import getPackageDir
 
 from lsst.sims.utils.CodeUtilities import sims_clean_up
 from lsst.sims.utils import ObservationMetaData
 from lsst.sims.catalogs.db import fileDBObject, CompoundCatalogDBObject, CatalogDBObject
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 def setup_module(module):
@@ -113,10 +116,9 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
                                                   for aa, bb, cc, dd in zip(aList, bList, cList, dList)],
                                                  dtype=dtype)
 
-        baseDir = os.path.join(getPackageDir('sims_catalogs'),
-                               'tests', 'scratchSpace')
+        cls.baseDir = tempfile.mkdtemp(dir=ROOT, prefix='scratchSpace-')
 
-        cls.textFileName = os.path.join(baseDir, 'compound_test_data.txt')
+        cls.textFileName = os.path.join(cls.baseDir, 'compound_test_data.txt')
         if os.path.exists(cls.textFileName):
             os.unlink(cls.textFileName)
 
@@ -125,11 +127,11 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
             for ix, (aa, bb, cc, dd) in enumerate(zip(aList, bList, cList, dList)):
                 output.write('%d %e %e %e %s\n' % (ix, aa, bb, cc, dd))
 
-        cls.dbName = os.path.join(baseDir, 'compoundCatalogTestDB.db')
+        cls.dbName = os.path.join(cls.baseDir, 'compoundCatalogTestDB.db')
         if os.path.exists(cls.dbName):
             os.unlink(cls.dbName)
 
-        cls.otherDbName = os.path.join(baseDir, 'otherDb.db')
+        cls.otherDbName = os.path.join(cls.baseDir, 'otherDb.db')
         if os.path.exists(cls.otherDbName):
             os.unlink(cls.otherDbName)
 
@@ -162,6 +164,8 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
             os.unlink(cls.dbName)
         if os.path.exists(cls.otherDbName):
             os.unlink(cls.otherDbName)
+        if os.path.exists(cls.baseDir):
+            shutil.rmtree(cls.baseDir)
 
     def testExceptions(self):
         """
@@ -535,8 +539,7 @@ class CompoundWithObsMetaData(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.baseDir = os.path.join(getPackageDir('sims_catalogs'),
-                                   'tests', 'scratchSpace')
+        cls.baseDir = tempfile.mkdtemp(dir=ROOT, prefix='scratchSpace-')
 
         cls.textFileName = os.path.join(cls.baseDir, 'compound_obs_metadata_text_data.txt')
 
@@ -587,6 +590,9 @@ class CompoundWithObsMetaData(unittest.TestCase):
 
         if os.path.exists(cls.dbName):
             os.unlink(cls.dbName)
+
+        if os.path.exists(cls.baseDir):
+            shutil.rmtree(cls.baseDir)
 
     def testObsMetaData(self):
         """

--- a/tests/testCompoundInstanceCatalog.py
+++ b/tests/testCompoundInstanceCatalog.py
@@ -2,19 +2,32 @@ from __future__ import with_statement
 from builtins import zip
 from builtins import range
 from builtins import object
+from builtins import super
 import os
 import numpy as np
 import unittest
+import tempfile
+import shutil
 import lsst.utils.tests
-from lsst.utils import getPackageDir
 from lsst.sims.utils.CodeUtilities import sims_clean_up
 from lsst.sims.utils import ObservationMetaData
 from lsst.sims.catalogs.db import fileDBObject, CatalogDBObject, CompoundCatalogDBObject
 from lsst.sims.catalogs.definitions import InstanceCatalog, CompoundInstanceCatalog
 
+ROOT = os.path.abspath(os.path.dirname(__file__))
+SCRATCH_DIR = None
+
 
 def setup_module(module):
+    global SCRATCH_DIR
     lsst.utils.tests.init()
+    SCRATCH_DIR = tempfile.mkdtemp(dir=ROOT, prefix="scratchSpace-")
+
+
+def teardown_module(module):
+    global SCRATCH_DIR
+    if os.path.exists(SCRATCH_DIR):
+        shutil.rmtree(SCRATCH_DIR)
 
 
 class negativeRaCompound(CompoundCatalogDBObject):
@@ -40,10 +53,22 @@ class negativeDecCompound_table2(CompoundCatalogDBObject):
 
 
 class cartoonDBbase(object):
-
     driver = 'sqlite'
-    database = os.path.join(getPackageDir('sims_catalogs'),
-                            'tests', 'scratchSpace', 'compound_db.db')
+    database = None
+
+    def __init__(self, *args, **kwargs):
+        """This base class is designed to specify a shared database that
+        all subclasses can use. This can not be set in a static class attribute
+        because the actually location is determined dynamically from mkdtemp
+        in setup_module() so that when this code is run in parallel each
+        process can have a different scratch space. This requires the constructor
+        to dynamically set the database class attribute the first time it is
+        called.
+        """
+        if self.database is None:
+            type(self).database = os.path.join(SCRATCH_DIR, 'compound_db.db')
+        super().__init__(*args, **kwargs)
+
 
 
 class table1DB1(CatalogDBObject, cartoonDBbase):
@@ -151,8 +176,7 @@ class CompoundCatalogTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.baseDir = os.path.join(getPackageDir('sims_catalogs'),
-                                   'tests', 'scratchSpace')
+        cls.baseDir = SCRATCH_DIR
 
         cls.table1FileName = os.path.join(cls.baseDir, 'compound_table1.txt')
         cls.table2FileName = os.path.join(cls.baseDir, 'compound_table2.txt')
@@ -767,6 +791,8 @@ class CompoundCatalogTest(unittest.TestCase):
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
     pass
 
+
 if __name__ == "__main__":
-    lsst.utils.tests.init()
+    setup_module(None)
     unittest.main()
+    teardown_module(None)

--- a/tests/testCompoundInstanceCatalog.py
+++ b/tests/testCompoundInstanceCatalog.py
@@ -794,5 +794,5 @@ class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
 
 if __name__ == "__main__":
     setup_module(None)
-    unittest.main()
+    unittest.main(exit=False)
     teardown_module(None)

--- a/tests/testConnectionCache.py
+++ b/tests/testConnectionCache.py
@@ -4,11 +4,14 @@ import unittest
 import sqlite3
 import os
 import numpy as np
+import tempfile
+import shutil
 
 import lsst.utils.tests
-from lsst.utils import getPackageDir
 from lsst.sims.utils.CodeUtilities import sims_clean_up
 from lsst.sims.catalogs.db import CatalogDBObject, DBObject
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 def setup_module(module):
@@ -23,8 +26,7 @@ class CachingTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.scratch_dir = os.path.join(getPackageDir("sims_catalogs"),
-                                       "tests", "scratchSpace")
+        cls.scratch_dir = tempfile.mkdtemp(dir=ROOT, prefix="scratchSpace-")
         cls.db_name = os.path.join(cls.scratch_dir, "connection_cache_test_db.db")
         if os.path.exists(cls.db_name):
             os.unlink(cls.db_name)
@@ -42,6 +44,9 @@ class CachingTestCase(unittest.TestCase):
         sims_clean_up()
         if os.path.exists(cls.db_name):
             os.unlink(cls.db_name)
+        if os.path.exists(cls.scratch_dir):
+            shutil.rmtree(cls.scratch_dir)
+
 
     def test_catalog_db_object_cacheing(self):
         """

--- a/tests/testConnectionPassing.py
+++ b/tests/testConnectionPassing.py
@@ -3,12 +3,15 @@ from builtins import range
 import unittest
 import os
 import numpy as np
+import tempfile
+import shutil
 import lsst.utils.tests
 
-from lsst.utils import getPackageDir
 from lsst.sims.utils.CodeUtilities import sims_clean_up
 from lsst.sims.catalogs.db import fileDBObject, CatalogDBObject
 from lsst.sims.catalogs.definitions import InstanceCatalog
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 def setup_module(module):
@@ -31,8 +34,7 @@ class ConnectionPassingTest(unittest.TestCase):
         cls.star_umag = np.random.random_sample(cls.n_stars)*10.0 + 15.0
         cls.star_gmag = np.random.random_sample(cls.n_stars)*10.0 + 15.0
 
-        cls.star_txt_name = os.path.join(getPackageDir('sims_catalogs'),
-                                         'tests', 'scratchSpace',
+        cls.star_txt_name = os.path.join(cls.scratch_dir,
                                          'ConnectionPassingTestStars.txt')
 
         if os.path.exists(cls.star_txt_name):
@@ -55,8 +57,7 @@ class ConnectionPassingTest(unittest.TestCase):
         cls.gal_umag = np.random.random_sample(cls.n_galaxies)*10.0+21.0
         cls.gal_gmag = np.random.random_sample(cls.n_galaxies)*10.0+21.0
 
-        cls.gal_txt_name = os.path.join(getPackageDir('sims_catalogs'),
-                                        'tests', 'scratchSpace',
+        cls.gal_txt_name = os.path.join(cls.scratch_dir,
                                         'ConnectionPassingTestGal.txt')
 
         if os.path.exists(cls.gal_txt_name):
@@ -73,11 +74,11 @@ class ConnectionPassingTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
 
+        cls.scratch_dir = tempfile.mkdtemp(dir=ROOT, prefix="scratchSpace-")
         cls.write_star_txt()
         cls.write_galaxy_txt()
 
-        cls.dbName = os.path.join(getPackageDir('sims_catalogs'), 'tests',
-                                  'scratchSpace', 'ConnectionPassingTestDB.db')
+        cls.dbName = os.path.join(cls.scratch_dir, 'ConnectionPassingTestDB.db')
 
         if os.path.exists(cls.dbName):
             os.unlink(cls.dbName)
@@ -113,6 +114,9 @@ class ConnectionPassingTest(unittest.TestCase):
         if os.path.exists(cls.gal_txt_name):
             os.unlink(cls.gal_txt_name)
 
+        if os.path.exists(cls.scratch_dir):
+            shutil.rmtree(cls.scratch_dir)
+
     def test_passing(self):
         """
         Test that we can produce a catalog of multiple object types
@@ -144,8 +148,7 @@ class ConnectionPassingTest(unittest.TestCase):
 
             default_formats = {'f': '%.4f'}
 
-        catName = os.path.join(getPackageDir('sims_catalogs'),
-                               'tests', 'scratchSpace',
+        catName = os.path.join(self.scratch_dir,
                                'ConnectionPassingTestOutputCatalog.txt')
 
         if os.path.exists(catName):

--- a/tests/testDBObject.py
+++ b/tests/testDBObject.py
@@ -7,9 +7,12 @@ import sys
 import numpy as np
 import unittest
 import warnings
+import tempfile
+import shutil
 import lsst.utils.tests
-from lsst.utils import getPackageDir
 from lsst.sims.catalogs.db import DBObject
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 def setup_module(module):
@@ -24,7 +27,7 @@ class DBObjectTestCase(unittest.TestCase):
         Create a database with two tables of meaningless data to make sure that JOIN queries
         can be executed using DBObject
         """
-        cls.scratch_dir = os.path.join(getPackageDir('sims_catalogs'), 'tests', 'scratchSpace')
+        cls.scratch_dir = tempfile.mkdtemp(dir=ROOT, prefix='scratchSpace-')
         cls.db_name = os.path.join(cls.scratch_dir, 'testDBObjectDB.db')
         if os.path.exists(cls.db_name):
             os.unlink(cls.db_name)
@@ -81,6 +84,8 @@ class DBObjectTestCase(unittest.TestCase):
     def tearDownClass(cls):
         if os.path.exists(cls.db_name):
             os.unlink(cls.db_name)
+        if os.path.exists(cls.scratch_dir):
+            shutil.rmtree(cls.scratch_dir)
 
     def setUp(self):
         self.driver = 'sqlite'

--- a/tests/testFileDBObject.py
+++ b/tests/testFileDBObject.py
@@ -3,9 +3,12 @@ from builtins import zip
 import unittest
 import os
 import numpy as np
+import shutil
+import tempfile
 import lsst.utils.tests
-from lsst.utils import getPackageDir
 from lsst.sims.catalogs.db import fileDBObject
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 def setup_module(module):
@@ -21,8 +24,12 @@ class FileDBObjectTestCase(unittest.TestCase):
     """
 
     def setUp(self):
-        self.scratch_dir = os.path.join(getPackageDir("sims_catalogs"),
-                                        "tests", "scratchSpace")
+        self.scratch_dir = tempfile.mkdtemp(dir=ROOT, prefix="scratchSpace-")
+
+
+    def tearDown(self):
+        if os.path.exists(self.scratch_dir):
+            shutil.rmtree(self.scratch_dir)
 
     def test_ingest(self):
         """

--- a/tests/testFilteringCatalogs.py
+++ b/tests/testFilteringCatalogs.py
@@ -3,13 +3,16 @@ from builtins import range
 import unittest
 import numpy as np
 import os
+import shutil
+import tempfile
 
 import lsst.utils.tests
-from lsst.utils import getPackageDir
 from lsst.sims.utils.CodeUtilities import sims_clean_up
 from lsst.sims.catalogs.definitions import InstanceCatalog, CompoundInstanceCatalog
 from lsst.sims.catalogs.db import fileDBObject, CatalogDBObject
 from lsst.sims.catalogs.decorators import cached, compound
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 def setup_module(module):
@@ -25,7 +28,7 @@ class InstanceCatalogTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.scratch_dir = os.path.join(getPackageDir('sims_catalogs'), 'tests', 'scratchSpace')
+        cls.scratch_dir = tempfile.mkdtemp(dir=ROOT, prefix="scratchSpace-")
 
         cls.db_src_name = os.path.join(cls.scratch_dir, 'inst_cat_filter_db.txt')
         if os.path.exists(cls.db_src_name):
@@ -49,6 +52,8 @@ class InstanceCatalogTestCase(unittest.TestCase):
 
         if os.path.exists(cls.db_src_name):
             os.unlink(cls.db_src_name)
+        if os.path.exists(cls.scratch_dir):
+            shutil.rmtree(cls.scratch_dir)
 
     def test_single_filter(self):
         """
@@ -617,7 +622,7 @@ class CompoundInstanceCatalogTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.scratch_dir = os.path.join(getPackageDir('sims_catalogs'), 'tests', 'scratchSpace')
+        cls.scratch_dir = tempfile.mkdtemp(dir=ROOT, prefix="scratchSpace-")
 
         cls.db_src_name = os.path.join(cls.scratch_dir, 'compound_cat_filter_db.txt')
         if os.path.exists(cls.db_src_name):
@@ -646,6 +651,9 @@ class CompoundInstanceCatalogTestCase(unittest.TestCase):
 
         if os.path.exists(cls.db_name):
             os.unlink(cls.db_name)
+
+        if os.path.exists(cls.scratch_dir):
+            shutil.rmtree(cls.scratch_dir)
 
     def test_compound_cat(self):
         """

--- a/tests/testInstanceCatalog.py
+++ b/tests/testInstanceCatalog.py
@@ -28,16 +28,20 @@ def setup_module(module):
     lsst.utils.tests.init()
 
 
-def createCannotBeNullTestDB(filename=None, add_nans=True):
+def createCannotBeNullTestDB(filename=None, add_nans=True, dir=None):
     """
     Create a database to test the 'cannot_be_null' functionality in InstanceCatalog
 
     This method will return the contents of the database as a recarray for baseline comparison
     in the unit tests.
+    If the filename is not specified, it will be written in to directory "dir" if not
+    none, else it will be written to the current directory
     """
 
     if filename is None:
         dbName = 'cannotBeNullTest.db'
+        if dir is not None:
+            dbName = os.path.join(dir, dbName)
     else:
         dbName = filename
 
@@ -339,7 +343,10 @@ class InstanceCatalogCannotBeNullTest(unittest.TestCase):
 
         def setUp(self):
             self.scratch_dir = tempfile.mkdtemp(dir=ROOT, prefix='scratchSpace-')
-            self.baselineOutput = createCannotBeNullTestDB()
+            # Force the class to understand where the DB is meant to be
+            myCannotBeNullDBObject.database = os.path.join(self.scratch_dir,
+                                                           'cannotBeNullTest.db')
+            self.baselineOutput = createCannotBeNullTestDB(dir=self.scratch_dir)
 
         def tearDown(self):
             del self.baselineOutput

--- a/tests/testInstanceCatalog.py
+++ b/tests/testInstanceCatalog.py
@@ -288,27 +288,25 @@ class InstanceCatalogMetaDataTest(unittest.TestCase):
         """
         Test that columns added using the contructor ags return the correct value
         """
-        dbName = 'valueTestDB.db'
-        baselineData = createCannotBeNullTestDB(filename=dbName, add_nans=False)
-        db = myCannotBeNullDBObject(driver='sqlite', database=dbName)
-        dtype = np.dtype([('n1', float), ('n2', float), ('n3', float), ('difference', float)])
-        cat = cartoonValueCatalog(db, column_outputs = ['n3', 'difference'])
+        with lsst.utils.tests.getTempFilePath(".db") as dbName:
+            baselineData = createCannotBeNullTestDB(filename=dbName, add_nans=False)
+            db = myCannotBeNullDBObject(driver='sqlite', database=dbName)
+            dtype = np.dtype([('n1', float), ('n2', float), ('n3', float), ('difference', float)])
+            cat = cartoonValueCatalog(db, column_outputs = ['n3', 'difference'])
 
-        columns = ['n1', 'n2', 'n3', 'difference']
-        for col in columns:
-            self.assertIn(col, cat._actually_calculated_columns)
+            columns = ['n1', 'n2', 'n3', 'difference']
+            for col in columns:
+                self.assertIn(col, cat._actually_calculated_columns)
 
-        cat_name = os.path.join(self.scratch_dir, 'cartoonValCat.txt')
-        cat.write_catalog(cat_name)
-        testData = np.genfromtxt(cat_name, dtype=dtype, delimiter=',')
-        for testLine, controlLine in zip(testData, baselineData):
-            self.assertAlmostEqual(testLine[0], controlLine['n1'], 6)
-            self.assertAlmostEqual(testLine[1], controlLine['n2'], 6)
-            self.assertAlmostEqual(testLine[2], controlLine['n3'], 6)
-            self.assertAlmostEqual(testLine[3], controlLine['n1']-controlLine['n3'], 6)
+            cat_name = os.path.join(self.scratch_dir, 'cartoonValCat.txt')
+            cat.write_catalog(cat_name)
+            testData = np.genfromtxt(cat_name, dtype=dtype, delimiter=',')
+            for testLine, controlLine in zip(testData, baselineData):
+                self.assertAlmostEqual(testLine[0], controlLine['n1'], 6)
+                self.assertAlmostEqual(testLine[1], controlLine['n2'], 6)
+                self.assertAlmostEqual(testLine[2], controlLine['n3'], 6)
+                self.assertAlmostEqual(testLine[3], controlLine['n1']-controlLine['n3'], 6)
 
-        if os.path.exists(dbName):
-            os.unlink(dbName)
         if os.path.exists(cat_name):
             os.unlink(cat_name)
 
@@ -324,16 +322,13 @@ class InstanceCatalogMetaDataTest(unittest.TestCase):
                 n3 = self.column_by_name('n3')
                 return n1-n3
 
-        dbName = 'valueTestDB.db'
-        createCannotBeNullTestDB(filename=dbName, add_nans=False)
-        db = myCannotBeNullDBObject(driver='sqlite', database=dbName)
-        cat = otherCartoonValueCatalog(db)
-        columns = ['n1', 'n2', 'n3', 'difference']
-        for col in columns:
-            self.assertIn(col, cat._actually_calculated_columns)
-
-        if os.path.exists('valueTestDB.db'):
-            os.unlink('valueTestDB.db')
+        with lsst.utils.tests.getTempFilePath(".db") as dbName:
+            createCannotBeNullTestDB(filename=dbName, add_nans=False)
+            db = myCannotBeNullDBObject(driver='sqlite', database=dbName)
+            cat = otherCartoonValueCatalog(db)
+            columns = ['n1', 'n2', 'n3', 'difference']
+            for col in columns:
+                self.assertIn(col, cat._actually_calculated_columns)
 
 
 class InstanceCatalogCannotBeNullTest(unittest.TestCase):

--- a/tests/testParallelCatalogWriter.py
+++ b/tests/testParallelCatalogWriter.py
@@ -274,5 +274,5 @@ class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
 
 if __name__ == "__main__":
     setup_module(None)
-    unittest.main()
+    unittest.main(exit=False)
     teardown_module(None)

--- a/tests/testParallelCatalogWriter.py
+++ b/tests/testParallelCatalogWriter.py
@@ -1,12 +1,14 @@
 from __future__ import with_statement
 from builtins import range
+from builtins import super
 import unittest
 import sqlite3
 import os
 import numpy as np
+import tempfile
+import shutil
 
 import lsst.utils.tests
-from lsst.utils import getPackageDir
 from lsst.sims.utils.CodeUtilities import sims_clean_up
 from lsst.sims.catalogs.definitions import parallelCatalogWriter
 from lsst.sims.catalogs.definitions import InstanceCatalog
@@ -14,20 +16,34 @@ from lsst.sims.catalogs.decorators import compound, cached
 from lsst.sims.catalogs.db import CatalogDBObject
 
 
+ROOT = os.path.abspath(os.path.dirname(__file__))
+SCRATCH_DIR = None
+
+
 def setup_module(module):
+    global SCRATCH_DIR
     lsst.utils.tests.init()
+    SCRATCH_DIR = tempfile.mkdtemp(dir=ROOT, prefix="scratchSpace-")
+
+
+def teardown_module(module):
+    global SCRATCH_DIR
+    if os.path.exists(SCRATCH_DIR):
+        shutil.rmtree(SCRATCH_DIR)
 
 
 class DbClass(CatalogDBObject):
     tableid = 'test'
-    database = os.path.join(getPackageDir('sims_catalogs'),
-                            'tests', 'scratchSpace', 'parallel_test_db.db')
 
     host = None
     port = None
     driver = 'sqlite'
     objid = 'parallel_writer_test_db'
     idColKey = 'id'
+
+    def __init__(self, **kwargs):
+        db = os.path.join(SCRATCH_DIR, 'parallel_test_db.db')
+        super().__init__(database=db, **kwargs)
 
 
 class ParallelCatClass1(InstanceCatalog):
@@ -74,8 +90,7 @@ class ParallelWriterTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.scratch_dir = os.path.join(getPackageDir('sims_catalogs'),
-                                       'tests', 'scratchSpace')
+        cls.scratch_dir = os.path.join(SCRATCH_DIR)
 
         cls.db_name = os.path.join(cls.scratch_dir, 'parallel_test_db.db')
         if os.path.exists(cls.db_name):
@@ -256,6 +271,8 @@ class ParallelWriterTestCase(unittest.TestCase):
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
     pass
 
+
 if __name__ == "__main__":
-    lsst.utils.tests.init()
+    setup_module(None)
     unittest.main()
+    teardown_module(None)


### PR DESCRIPTION
When pytest runs jobs in parallel, multiple tests will be using the
scratch directories. This caused many tests to fail as they were
racing each other to database files and SQLite reported many
problems.

This patch rewrites the tests to use mkdtemp(). Two of the tests,
testCompoundInstanceCatalog and testCatalogDBObject, use the scratch
space in class attributes. This leads to somewhat convoluted logic
where the temp directory is allocated at setup_module(), which
runs after the code has been imported (so the temporary directory
can not be known to the class immediately), and the class has
to have an __init__ call that assigns the database location.

One improvement would be to assign the scratch space based on
the name of the class, but for now I've used "scratchSpace-"
as the prefix. This has been tested with multiple pytest
processes and seems to be working well.