### PR TITLE
U/danielsf/dc2/filter

### DIFF
--- a/python/lsst/sims/catalogs/db/CompoundCatalogDBObject.py
+++ b/python/lsst/sims/catalogs/db/CompoundCatalogDBObject.py
@@ -143,6 +143,10 @@ class _CompoundCatalogDBObject_mixin(object):
                 self._compound_dbo_name_map[column_row[0]] = column_row[0]
 
     def name_map(self, name):
+        """
+        Map a column name with the CatalogDBObject's objid prepended to the
+        name of the column that will actually be queried from the database
+        """
         if not hasattr(self, '_compound_dbo_name_map'):
             raise RuntimeError("This CompoundCatalogDBObject does not have a name_map")
         return self._compound_dbo_name_map[name]

--- a/python/lsst/sims/catalogs/db/CompoundCatalogDBObject.py
+++ b/python/lsst/sims/catalogs/db/CompoundCatalogDBObject.py
@@ -27,6 +27,7 @@ class _CompoundCatalogDBObject_mixin(object):
         for dbo, dbName in zip(self._dbObjectClassList, self._nameList):
             db_inst = dbo()
             for row in db_inst.columns:
+                print(row, dbName)
                 all_rows.append(row)
                 raw_column_names.append(row[1])
                 processed_column_names.append(row[0])

--- a/python/lsst/sims/catalogs/db/CompoundCatalogDBObject.py
+++ b/python/lsst/sims/catalogs/db/CompoundCatalogDBObject.py
@@ -27,7 +27,6 @@ class _CompoundCatalogDBObject_mixin(object):
         for dbo, dbName in zip(self._dbObjectClassList, self._nameList):
             db_inst = dbo()
             for row in db_inst.columns:
-                print(row, dbName)
                 all_rows.append(row)
                 raw_column_names.append(row[1])
                 processed_column_names.append(row[0])

--- a/python/lsst/sims/catalogs/db/CompoundCatalogDBObject.py
+++ b/python/lsst/sims/catalogs/db/CompoundCatalogDBObject.py
@@ -18,65 +18,129 @@ class _CompoundCatalogDBObject_mixin(object):
         from the input CatalogDBObjects and modifying the names of the returned
         columns to identify them with their specific CatalogDBObjects.
         """
-        column_names = []
-        preliminary_columns = {}
-        preliminary_column_name_map = {}
+        raw_column_names = []  # the names as they appear on the database
+        processed_column_names = []  # the names as they appear in the CatalogDBObject
+        prefix_column_names = []  # the names with the objid added
+        raw_column_transform = []  # the full transform applied by the CatalogDBObject
+        all_rows = []  # store the raw rows for the last block of code in this method
+
         for dbo, dbName in zip(self._dbObjectClassList, self._nameList):
             db_inst = dbo()
             for row in db_inst.columns:
-                new_row = [ww for ww in row]
-                new_row[0] = str('%s_%s' % (dbName, row[0]))
-                if new_row[1] is None:
-                    new_row[1] = row[0]
-                column_key = tuple(new_row[1:])
-                if column_key not in preliminary_columns:
-                    preliminary_columns[column_key] = []
-                    preliminary_column_name_map[column_key] = (row[0], new_row[0])
-                preliminary_columns[column_key].append(tuple(new_row))
-                column_names.append(new_row[0])
+                all_rows.append(row)
+                raw_column_names.append(row[1])
+                processed_column_names.append(row[0])
+                prefix_column_names.append('%s_%s' % (dbName, row[0]))
+                raw_column_transform.append(row[1:])
 
-                # 25 August 2015
-                # This is a modification that needs to be made in order for this
-                # class to work with GalaxyTileObj.  The column galaxytileid in
-                # GalaxyTileObj is removed from the query by query_columns, but
-                # somehow injected back in by the query procedure on fatboy. This
-                # leads to confusion if you try to query something like
-                # galaxyAgn_galaxytileid.  We deal with that by removing all column
-                # names like 'galaxytileid' in query_columns, but leaving 'galaxytileid'
-                # un-mangled in self.columns so that self.typeMap knows how to deal
-                # with it when it comes back.
-                if row[0] not in column_names and (row[1] is None or row[1] == row[0]):
-                    preliminary_columns[column_key].append(row)
-                    column_names.append(row[0])
-
-        use_prefix_list = []
-        column_name_map = {}
-        for column_key in preliminary_column_name_map:
-            if preliminary_column_name_map[column_key][0] in use_prefix_list:
-                column_name_map[column_key] = preliminary_column_name_map[column_key][1]
-                continue
-            use_prefix = False
-            for column_key2 in preliminary_column_name_map:
-                if column_key2 == column_key:
-                    continue
-                if preliminary_column_name_map[column_key][0] == preliminary_column_name_map[column_key2][0]:
-                    use_prefix_list.append(preliminary_column_name_map[column_key][0])
-                    use_prefix = True
-                    break
-            if use_prefix:
-                column_name_map[column_key] = preliminary_column_name_map[column_key][1]
-            else:
-                column_name_map[column_key] = preliminary_column_name_map[column_key][0]
 
         self._compound_dbo_name_map = {}
         self.columns = []
-        for column_key in preliminary_column_name_map:
-            new_row = [column_name_map[column_key]]
-            for nn in column_key:
-                new_row.append(nn)
-            self.columns.append(tuple(new_row))
-            for prelim_row in preliminary_columns[column_key]:
-                self._compound_dbo_name_map[prelim_row[0]] = new_row[0]
+        processed_columns_requiring_prefix = set()
+        column_diagnostic = {}
+
+        # Now we need to figure out which of the CatalogDBObject-mapped columns
+        # actually need to be kept independent (i.e sedFilename for galaxy bulges will
+        # not actually be referencing the same column as sedFilename for galaxy disks)
+        # and which can be lumped together (i.e. redshift will be the same database
+        # column for galaxy bulges and disks)
+        for i_r1 in range(len(raw_column_names)):
+
+            # if a processed column has already been determined to be degenerate,
+            # just acknowledget that
+            use_prefix = processed_column_names[i_r1] in processed_columns_requiring_prefix
+
+            if not use_prefix:
+                # If two CatalogDBObjects map different columns in the raw database to
+                # the same transformed column name, then we need to keep the two
+                # distinct in this CompoundCatalogDBObject; we do that by using the
+                # prefix_name, which prepends the objid of the CatalogDBobject to the
+                # transformed column
+                for i_r2 in range(i_r1+1, len(raw_column_names)):
+                    if (processed_column_names[i_r1] == processed_column_names[i_r2] and
+                        raw_column_transform[i_r1] != raw_column_transform[i_r2]):
+
+                        use_prefix = True
+                        break
+
+                if use_prefix:
+                    processed_columns_requiring_prefix.add(processed_column_names[i_r1])
+
+            # under what name will the column actually be queried
+            if use_prefix:
+                query_name = prefix_column_names[i_r1]
+            else:
+                query_name = processed_column_names[i_r1]
+
+
+            if prefix_column_names[i_r1] in self._compound_dbo_name_map:
+                raise RuntimeError("Trying to put %s in compound_db_name_map twice" %
+                                   prefix_column_names[i_r1])
+
+            # build the dict that maps the prefixed column names, which CompoundInstanceCatalog
+            # will reference, to the names that are actually going to be queried from
+            # this CompoundCatalogDBObject
+            self._compound_dbo_name_map[prefix_column_names[i_r1]] = query_name
+
+            # build the self.columns member variable of this CompoundCatalogDBObject
+            column_row = [query_name]
+            column_row += [ww for ww in raw_column_transform[i_r1]]
+
+            # if no transformation was applied, we need to map the column
+            # back to the database column of the same name
+            if column_row[1] is None:
+                column_row[1] = processed_column_names[i_r1]
+
+            column_row = tuple(column_row)
+
+            if column_row[0] in column_diagnostic:
+                if column_row != column_diagnostic[column_row[0]]:
+                    row1 = column_row
+                    row2 = column_diagnostic[column_row[0]]
+                    raise RuntimeError("Trying to change definition of columns "
+                                       + "\n%s\n%s\n" % (row1, row2))
+
+            if column_row not in self.columns:
+                self.columns.append(column_row)
+                column_diagnostic[column_row[0]] = column_row
+
+        # 8 November 2018 (originally 25 August 2015)
+        # This is a modification that needs to be made in order for this
+        # class to work with GalaxyTileObj.  The column galaxytileid in
+        # GalaxyTileObj is removed from the query by query_columns, but
+        # somehow injected back in by the query procedure on fatboy. This
+        # leads to confusion if you try to query something like
+        # galaxyAgn_galaxytileid.  We deal with that by removing all column
+        # names like 'galaxytileid' in query_columns, but leaving 'galaxytileid'
+        # un-mangled in self.columns so that self.typeMap knows how to deal
+        # with it when it comes back
+
+        for column_row in all_rows:
+            if (column_row[0] not in self._compound_dbo_name_map and
+                (column_row[1] is None or column_row[1] == column_row[0])):
+
+                # again: deal with cases where no transformation is applied
+                if column_row[1] is None:
+                    new_row = [ww for ww in column_row]
+                    new_row[1] = new_row[0]
+                    column_row = tuple(new_row)
+
+                if column_row[0] in column_diagnostic:
+                    if column_row != column_diagnostic[column_row[0]]:
+                        row1 = column_row
+                        row2 = column_diagnostic[column_row[0]]
+                        raise RuntimeError("Trying to change definition of columns "
+                                           + "\n%s\n%s\n" % (row1, row2))
+
+                if column_row not in self.columns:
+                    self.columns.append(column_row)
+                    column_diagnostic[column_row[0]] = column_row
+
+                if column_row[0] in self._compound_dbo_name_map:
+                    if column_row[0] != self._column_dbo_name_map[column_row[0]]:
+                        raise RuntimeError("Column name map conflict")
+
+                self._compound_dbo_name_map[column_row[0]] = column_row[0]
 
     def name_map(self, name):
         if not hasattr(self, '_compound_dbo_name_map'):

--- a/python/lsst/sims/catalogs/db/CompoundCatalogDBObject.py
+++ b/python/lsst/sims/catalogs/db/CompoundCatalogDBObject.py
@@ -151,6 +151,11 @@ class CompoundCatalogDBObject(CatalogDBObject):
             for prelim_row in preliminary_columns[column_key]:
                 self._compound_dbo_name_map[prelim_row[0]] = new_row[0]
 
+    def name_map(self, name):
+        if not hasattr(self, '_compound_dbo_name_map'):
+            raise RuntimeError("This CompoundCatalogDBObject does not have a name_map")
+        return self._compound_dbo_name_map[name]
+
     def _make_dbTypeMap(self):
         """
         Construct the self.dbTypeMap member by concatenating the self.dbTypeMaps

--- a/python/lsst/sims/catalogs/db/dbConnection.py
+++ b/python/lsst/sims/catalogs/db/dbConnection.py
@@ -745,12 +745,14 @@ class CatalogDBObject(with_metaclass(CatalogDBObjectMeta, DBObject)):
         try:
             vals = [self.columnMap[k] for k in colnames]
         except KeyError:
+            offending_columns = '\n'
             for col in colnames:
                 if col in self.columnMap:
                     continue
                 else:
-                    warnings.warn("%s not in columnMap"%(col))
-            raise ValueError('entries in colnames must be in self.columnMap')
+                    offending_columns +='%s\n' % col
+            raise ValueError('entries in colnames must be in self.columnMap. '
+                             'These:%sare not' % offending_columns)
 
         # Get the first query
         idColName = self.columnMap[self.idColKey]

--- a/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
@@ -315,5 +315,6 @@ class CompoundInstanceCatalog(object):
 
                     local_recarray.dtype = new_dtype_list[ix]
                     cat._write_recarray(local_recarray, file_handle)
+                    cat._delete_current_chunk()
 
                 first_chunk = False

--- a/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
@@ -279,7 +279,6 @@ class CompoundInstanceCatalog(object):
                 prefixed_name = '%s_%s' % (name, colName)
                 query_name = compound_dbo.name_map(prefixed_name)
                 if query_name not in colnames:
-                    print('querying %s -> %s' % (prefixed_name, query_name))
                     colnames.append(query_name)
                 localNames.append(query_name)
                 local_map[query_name] = colName

--- a/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
@@ -279,6 +279,7 @@ class CompoundInstanceCatalog(object):
                 prefixed_name = '%s_%s' % (name, colName)
                 query_name = compound_dbo.name_map(prefixed_name)
                 if query_name not in colnames:
+                    print('querying %s -> %s' % (prefixed_name, query_name))
                     colnames.append(query_name)
                 localNames.append(query_name)
                 local_map[query_name] = colName

--- a/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
@@ -281,7 +281,7 @@ class CompoundInstanceCatalog(object):
                 if query_name not in colnames:
                     colnames.append(query_name)
                 localNames.append(query_name)
-                local_map[prefixed_name] = colName
+                local_map[query_name] = colName
             master_colnames.append(localNames)
             name_map.append(local_map)
 

--- a/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
@@ -277,7 +277,7 @@ class CompoundInstanceCatalog(object):
             local_map = {}
             for colName in cat._active_columns:
                 prefixed_name = '%s_%s' % (name, colName)
-                query_name = compound_dbo._compound_dbo_name_map[prefixed_name]
+                query_name = compound_dbo.name_map(prefixed_name)
                 if query_name not in colnames:
                     colnames.append(query_name)
                 localNames.append(query_name)

--- a/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/CompoundInstanceCatalog.py
@@ -276,9 +276,12 @@ class CompoundInstanceCatalog(object):
             localNames = []
             local_map = {}
             for colName in cat._active_columns:
-                colnames.append('%s_%s' % (name, colName))
-                localNames.append('%s_%s' % (name, colName))
-                local_map['%s_%s' % (name, colName)] = colName
+                prefixed_name = '%s_%s' % (name, colName)
+                query_name = compound_dbo._compound_dbo_name_map[prefixed_name]
+                if query_name not in colnames:
+                    colnames.append(query_name)
+                localNames.append(query_name)
+                local_map[prefixed_name] = colName
             master_colnames.append(localNames)
             name_map.append(local_map)
 

--- a/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
@@ -583,10 +583,14 @@ class InstanceCatalog(with_metaclass(InstanceCatalogMeta, object)):
                     print('filtering %s as float (not prefilter)' % filter_col)
                     local_switch = np.isfinite(filter_vals)
                 else:
-                    print('filtering %s as a string (not prefilter)' % filter_col)
-                    filter_vals = np.char.lower(filter_vals.astype('str'))
-                    local_switch = np.logical_and(filter_vals != 'none',
-                                                  np.logical_and(filter_vals  != 'nan', filter_vals != 'null'))
+                    try:
+                       filter_vals = filter_vals.astype(float)
+                       local_switch = np.isfinite(filter_vals)
+                    except ValueError:
+                        print('filtering %s as a string (not prefilter)' % filter_col)
+                        filter_vals = np.char.lower(filter_vals.astype('str'))
+                        local_switch = np.logical_and(filter_vals != 'none',
+                                                      np.logical_and(filter_vals  != 'nan', filter_vals != 'null'))
                 if filter_switch is None:
                     filter_switch = local_switch
                 else:

--- a/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
@@ -564,6 +564,7 @@ class InstanceCatalog(with_metaclass(InstanceCatalogMeta, object)):
                         print('filtering %s as float' % col_name)
                         good_dexes = np.where(np.isfinite(chunk[col_name]))
                     else:
+                        print('filtering %s as a string' % col_name)
                         str_vec = np.char.lower(chunk[col_name].astype('str'))
                         good_dexes = np.where(np.logical_and(str_vec != 'none',
                                               np.logical_and(str_vec != 'nan', str_vec != 'null')))
@@ -581,6 +582,7 @@ class InstanceCatalog(with_metaclass(InstanceCatalogMeta, object)):
                     print('filtering %s as float (not prefilter)' % filter_col)
                     good_dexes = np.where(np.isfinite(filter_vals))
                 else:
+                    print('filtering %s as a string (not prefilter)' % filter_col)
                     filter_vals = np.char.lower(filter_vals.astype('str'))
                     good_dexes = np.where(np.logical_and(filter_vals != 'none',
                                           np.logical_and(filter_vals  != 'nan', filter_vals != 'null')))

--- a/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
@@ -327,6 +327,17 @@ class InstanceCatalog(with_metaclass(InstanceCatalogMeta, object)):
         else:
             self._column_cache = column_cache
 
+    def _delete_current_chunk(self):
+        """
+        Set the column cache and _current_chunk to None.
+        This is just going to be called by the
+        CompoundInstanceCatalog._write_compound method to try to control
+        memory bloat as multiple copies of the returned database query
+        accumulate in the different InstanceCatalogs being written.
+        """
+        self._column_cache = {}
+        self._current_chunk = None
+
     def db_required_columns(self):
         """Get the list of columns required to be in the database object."""
         saved_cache = self._cached_columns

--- a/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/definitions/InstanceCatalog.py
@@ -572,10 +572,8 @@ class InstanceCatalog(with_metaclass(InstanceCatalogMeta, object)):
             for col_name in self._cannot_be_null:
                 if col_name in chunk.dtype.names:
                     if chunk[col_name].dtype == float:
-                        print('filtering %s as float' % col_name)
                         good_dexes = np.where(np.isfinite(chunk[col_name]))
                     else:
-                        print('filtering %s as a string' % col_name)
                         str_vec = np.char.lower(chunk[col_name].astype('str'))
                         good_dexes = np.where(np.logical_and(str_vec != 'none',
                                               np.logical_and(str_vec != 'nan', str_vec != 'null')))
@@ -591,14 +589,12 @@ class InstanceCatalog(with_metaclass(InstanceCatalogMeta, object)):
             for filter_col in self._cannot_be_null:
                 filter_vals = self.column_by_name(filter_col)
                 if filter_vals.dtype == float:
-                    print('filtering %s as float (not prefilter)' % filter_col)
                     local_switch = np.isfinite(filter_vals)
                 else:
                     try:
                        filter_vals = filter_vals.astype(float)
                        local_switch = np.isfinite(filter_vals)
                     except ValueError:
-                        print('filtering %s as a string (not prefilter)' % filter_col)
                         filter_vals = np.char.lower(filter_vals.astype('str'))
                         local_switch = np.logical_and(filter_vals != 'none',
                                                       np.logical_and(filter_vals  != 'nan', filter_vals != 'null'))

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -680,7 +680,7 @@ class CompoundWithObsMetaData(unittest.TestCase):
         self.assertGreater(len(good_rows), 0)
         self.assertGreater(len(bad_rows), 0)
 
-    def testContraint(self):
+    def testConstraint(self):
         """
         Test that CompoundCatalogDBObject runs correctly with a constraint
         """
@@ -698,11 +698,13 @@ class CompoundWithObsMetaData(unittest.TestCase):
 
         compoundDb = CompoundCatalogDBObject([db1, db2])
 
-        colnames = ['%s_id' % db1.objid,
-                    '%s_raJ2000' % db1.objid, '%s_decJ2000' % db1.objid,
-                    '%s_magMod' % db1.objid,
-                    '%s_raJ2000' % db2.objid, '%s_decJ2000' % db2.objid,
-                    '%s_magMod' % db2.objid]
+        prefix_colnames = ['%s_id' % db1.objid,
+                           '%s_raJ2000' % db1.objid, '%s_decJ2000' % db1.objid,
+                           '%s_magMod' % db1.objid,
+                           '%s_raJ2000' % db2.objid, '%s_decJ2000' % db2.objid,
+                           '%s_magMod' % db2.objid]
+
+        colnames = numpy.unique([compoundDb.name_map(name) for name in prefix_colnames])
 
         results = compoundDb.query_columns(colnames=colnames,
                                            constraint='mag<11.0')
@@ -712,12 +714,24 @@ class CompoundWithObsMetaData(unittest.TestCase):
             for line in chunk:
                 ix = int(line['id'])
                 good_rows.append(ix)
-                self.assertAlmostEqual(line['%s_raJ2000' % db1.objid], self.controlArray['ra'][ix], 10)
-                self.assertAlmostEqual(line['%s_decJ2000' % db1.objid], self.controlArray['dec'][ix], 10)
-                self.assertAlmostEqual(line['%s_magMod' % db1.objid], self.controlArray['mag'][ix], 10)
-                self.assertAlmostEqual(line['%s_raJ2000' % db2.objid], 2.0*self.controlArray['ra'][ix], 10)
-                self.assertAlmostEqual(line['%s_decJ2000' % db2.objid], 2.0*self.controlArray['dec'][ix], 10)
-                self.assertAlmostEqual(line['%s_magMod' % db2.objid], 2.0*self.controlArray['mag'][ix], 10)
+                self.assertAlmostEqual(line[compoundDb.name_map('%s_raJ2000' % db1.objid)],
+                                       self.controlArray['ra'][ix], 10)
+
+                self.assertAlmostEqual(line[compoundDb.name_map('%s_decJ2000' % db1.objid)],
+                                       self.controlArray['dec'][ix], 10)
+
+                self.assertAlmostEqual(line[compoundDb.name_map('%s_magMod' % db1.objid)],
+                                       self.controlArray['mag'][ix], 10)
+
+                self.assertAlmostEqual(line[compoundDb.name_map('%s_raJ2000' % db2.objid)],
+                                       2.0*self.controlArray['ra'][ix], 10)
+
+                self.assertAlmostEqual(line[compoundDb.name_map('%s_decJ2000' % db2.objid)],
+                                       2.0*self.controlArray['dec'][ix], 10)
+
+                self.assertAlmostEqual(line[compoundDb.name_map('%s_magMod' % db2.objid)],
+                                       2.0*self.controlArray['mag'][ix], 10)
+
                 self.assertLess(self.controlArray['mag'][ix], 11.0)
 
         bad_rows = [ii for ii in range(self.controlArray.shape[0]) if ii not in good_rows]

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -326,24 +326,26 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
         dbList = [db1, db2]
         compoundDb = specificCompoundObj_test(dbList)
 
-        colNames = ['%s_aa' % db1.objid, '%s_bb' % db1.objid,
-                    '%s_aa' % db2.objid, '%s_bb' % db2.objid]
+        prefix_colNames = ['%s_aa' % db1.objid, '%s_bb' % db1.objid,
+                           '%s_aa' % db2.objid, '%s_bb' % db2.objid]
+
+        colNames = numpy.unique([compoundDb.name_map(name) for name in prefix_colNames])
 
         results = compoundDb.query_columns(colnames=colNames)
 
         for chunk in results:
-            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db1.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_aa' % db1.objid)],
                                                     self.controlArray['a'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_equal(chunk['%s_bb' % db1.objid],
+            numpy.testing.assert_array_equal(chunk[compoundDb.name_map('%s_bb' % db1.objid)],
                                              self.controlArray['d'])
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db2.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_aa' % db2.objid)],
                                                     2.0*self.controlArray['b'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_bb' % db2.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_bb' % db2.objid)],
                                                     self.controlArray['a'],
                                                     decimal=6)
 

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -372,38 +372,40 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
         dbList = [db1, db2, db3]
         compoundDb = universalCompoundObj(dbList)
 
-        colNames = ['%s_aa' % db1.objid, '%s_bb' % db1.objid,
-                    '%s_aa' % db2.objid, '%s_bb' % db2.objid,
-                    '%s_aa' % db3.objid, '%s_bb' % db3.objid,
-                    '%s_cc' % db3.objid]
+        prefix_colNames = ['%s_aa' % db1.objid, '%s_bb' % db1.objid,
+                           '%s_aa' % db2.objid, '%s_bb' % db2.objid,
+                           '%s_aa' % db3.objid, '%s_bb' % db3.objid,
+                           '%s_cc' % db3.objid]
+
+        colNames = numpy.unique([compoundDb.name_map(name) for name in prefix_colNames])
 
         results = compoundDb.query_columns(colnames=colNames)
 
         for chunk in results:
-            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db1.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_aa' % db1.objid)],
                                                     self.controlArray['a'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_equal(chunk['%s_bb' % db1.objid],
+            numpy.testing.assert_array_equal(chunk[compoundDb.name_map('%s_bb' % db1.objid)],
                                              self.controlArray['d'])
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db2.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_aa' % db2.objid)],
                                                     2.0*self.controlArray['b'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_bb' % db2.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_bb' % db2.objid)],
                                                     self.controlArray['a'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db3.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_aa' % db3.objid)],
                                                     self.controlArray['c']-3.0,
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_bb' % db3.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_bb' % db3.objid)],
                                                     self.controlArray['a'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_cc' % db3.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_cc' % db3.objid)],
                                                     3.0*self.controlArray['b'],
                                                     decimal=6)
 

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -432,11 +432,13 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
         dbList = [db1, db2, db3]
         compoundDb = CompoundCatalogDBObject(dbList)
 
-        colNames = ['id',
-                    '%s_aa' % db1.objid, '%s_bb' % db1.objid,
-                    '%s_aa' % db2.objid, '%s_bb' % db2.objid,
-                    '%s_aa' % db3.objid, '%s_bb' % db3.objid,
-                    '%s_cc' % db3.objid]
+        prefix_colNames = ['id',
+                           '%s_aa' % db1.objid, '%s_bb' % db1.objid,
+                           '%s_aa' % db2.objid, '%s_bb' % db2.objid,
+                           '%s_aa' % db3.objid, '%s_bb' % db3.objid,
+                           '%s_cc' % db3.objid]
+
+        colNames = numpy.unique([compoundDb.name_map(name) for name in prefix_colNames])
 
         results = compoundDb.query_columns(colnames=colNames, chunk_size=10)
 
@@ -447,30 +449,30 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
             rows = chunk['id']
             self.assertLessEqual(len(rows), 10)
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db1.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_aa' % db1.objid)],
                                                     self.controlArray['a'][rows],
                                                     decimal=6)
 
-            numpy.testing.assert_array_equal(chunk['%s_bb' % db1.objid],
+            numpy.testing.assert_array_equal(chunk[compoundDb.name_map('%s_bb' % db1.objid)],
                                              self.controlArray['d'][rows])
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db2.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_aa' % db2.objid)],
                                                     2.0*self.controlArray['b'][rows],
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_bb' % db2.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_bb' % db2.objid)],
                                                     self.controlArray['a'][rows],
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db3.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_aa' % db3.objid)],
                                                     self.controlArray['c'][rows]-3.0,
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_bb' % db3.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_bb' % db3.objid)],
                                                     self.controlArray['a'][rows],
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_cc' % db3.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_cc' % db3.objid)],
                                                     3.0*self.controlArray['b'][rows],
                                                     decimal=6)
 

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -631,11 +631,13 @@ class CompoundWithObsMetaData(unittest.TestCase):
 
         compoundDb = CompoundCatalogDBObject([db1, db2])
 
-        colnames = ['%s_id' % db1.objid,
-                    '%s_raJ2000' % db1.objid, '%s_decJ2000' % db1.objid,
-                    '%s_magMod' % db1.objid,
-                    '%s_raJ2000' % db2.objid, '%s_decJ2000' % db2.objid,
-                    '%s_magMod' % db2.objid]
+        prefix_colnames = ['%s_id' % db1.objid,
+                           '%s_raJ2000' % db1.objid, '%s_decJ2000' % db1.objid,
+                           '%s_magMod' % db1.objid,
+                           '%s_raJ2000' % db2.objid, '%s_decJ2000' % db2.objid,
+                           '%s_magMod' % db2.objid]
+
+        colnames = numpy.unique([compoundDb.name_map(name) for name in prefix_colnames])
 
         results = compoundDb.query_columns(colnames=colnames,
                                            obs_metadata=obs)
@@ -645,12 +647,24 @@ class CompoundWithObsMetaData(unittest.TestCase):
             for line in chunk:
                 ix = int(line['id'])
                 good_rows.append(ix)
-                self.assertAlmostEqual(line['%s_raJ2000' % db1.objid], self.controlArray['ra'][ix], 10)
-                self.assertAlmostEqual(line['%s_decJ2000' % db1.objid], self.controlArray['dec'][ix], 10)
-                self.assertAlmostEqual(line['%s_magMod' % db1.objid], self.controlArray['mag'][ix], 10)
-                self.assertAlmostEqual(line['%s_raJ2000' % db2.objid], 2.0*self.controlArray['ra'][ix], 10)
-                self.assertAlmostEqual(line['%s_decJ2000' % db2.objid], 2.0*self.controlArray['dec'][ix], 10)
-                self.assertAlmostEqual(line['%s_magMod' % db2.objid], 2.0*self.controlArray['mag'][ix], 10)
+                self.assertAlmostEqual(line[compoundDb.name_map('%s_raJ2000' % db1.objid)],
+                                       self.controlArray['ra'][ix], 10)
+
+                self.assertAlmostEqual(line[compoundDb.name_map('%s_decJ2000' % db1.objid)],
+                                       self.controlArray['dec'][ix], 10)
+
+                self.assertAlmostEqual(line[compoundDb.name_map('%s_magMod' % db1.objid)],
+                                       self.controlArray['mag'][ix], 10)
+
+                self.assertAlmostEqual(line[compoundDb.name_map('%s_raJ2000' % db2.objid)],
+                                       2.0*self.controlArray['ra'][ix], 10)
+
+                self.assertAlmostEqual(line[compoundDb.name_map('%s_decJ2000' % db2.objid)],
+                                       2.0*self.controlArray['dec'][ix], 10)
+
+                self.assertAlmostEqual(line[compoundDb.name_map('%s_magMod' % db2.objid)],
+                                       2.0*self.controlArray['mag'][ix], 10)
+
                 self.assertGreater(self.controlArray['ra'][ix], 100.0)
                 self.assertLess(self.controlArray['ra'][ix], 260.0)
                 self.assertGreater(self.controlArray['dec'][ix], -25.0)

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -246,7 +246,7 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
         msg = "This CompoundCatalogDBObject does not support the table 'test'"
         self.assertIn(msg, context.exception.args[0])
 
-    def testCompoundCatalogDBObject(self):
+    def testCompoundCatalogDBObject_method(self):
         """
         Verify that CompoundCatalogDBObject returns the expected
         columns.
@@ -271,38 +271,40 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
         dbList = [db1, db2, db3]
         compoundDb = CompoundCatalogDBObject(dbList)
 
-        colNames = ['%s_aa' % db1.objid, '%s_bb' % db1.objid,
-                    '%s_aa' % db2.objid, '%s_bb' % db2.objid,
-                    '%s_aa' % db3.objid, '%s_bb' % db3.objid,
-                    '%s_cc' % db3.objid]
+        prefixed_colNames = ['%s_aa' % db1.objid, '%s_bb' % db1.objid,
+                            '%s_aa' % db2.objid, '%s_bb' % db2.objid,
+                            '%s_aa' % db3.objid, '%s_bb' % db3.objid,
+                            '%s_cc' % db3.objid]
+
+        colNames = numpy.unique([compoundDb.name_map(name) for name in prefixed_colNames])
 
         results = compoundDb.query_columns(colnames=colNames)
 
         for chunk in results:
-            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db1.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_aa' % db1.objid)],
                                                     self.controlArray['a'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_equal(chunk['%s_bb' % db1.objid],
+            numpy.testing.assert_array_equal(chunk[compoundDb.name_map('%s_bb' % db1.objid)],
                                              self.controlArray['d'])
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db2.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_aa' % db2.objid)],
                                                     2.0*self.controlArray['b'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_bb' % db2.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_bb' % db2.objid)],
                                                     self.controlArray['a'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db3.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_aa' % db3.objid)],
                                                     self.controlArray['c']-3.0,
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_bb' % db3.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_bb' % db3.objid)],
                                                     self.controlArray['a'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_cc' % db3.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_cc' % db3.objid)],
                                                     3.0*self.controlArray['b'],
                                                     decimal=6)
 

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -494,25 +494,29 @@ class CompoundCatalogDBObjectTestCase(unittest.TestCase):
 
         db1 = testDbClass20
         db2 = testDbClass21
-        colNames = ['%s_aa' % db1.objid, '%s_bb' % db1.objid,
-                    '%s_a' % db2.objid, '%s_b' % db2.objid]
 
         compoundDb = CompoundCatalogDBObject([db1, db2])
+
+        prefix_colNames = ['%s_aa' % db1.objid, '%s_bb' % db1.objid,
+                           '%s_a' % db2.objid, '%s_b' % db2.objid]
+
+        colNames = numpy.unique([compoundDb.name_map(name) for name in prefix_colNames])
+
         results = compoundDb.query_columns(colnames=colNames)
 
         for chunk in results:
-            numpy.testing.assert_array_almost_equal(chunk['%s_aa' % db1.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_aa' % db1.objid)],
                                                     self.controlArray['a'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_equal(chunk['%s_bb' % db1.objid],
+            numpy.testing.assert_array_equal(chunk[compoundDb.name_map('%s_bb' % db1.objid)],
                                              self.controlArray['d'])
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_a' % db2.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_a' % db2.objid)],
                                                     self.controlArray['a'],
                                                     decimal=6)
 
-            numpy.testing.assert_array_almost_equal(chunk['%s_b' % db2.objid],
+            numpy.testing.assert_array_almost_equal(chunk[compoundDb.name_map('%s_b' % db2.objid)],
                                                     self.controlArray['b'],
                                                     decimal=6)
 

--- a/tests/testCompoundCatalogDBObject.py
+++ b/tests/testCompoundCatalogDBObject.py
@@ -767,11 +767,13 @@ class CompoundWithObsMetaData(unittest.TestCase):
 
         compoundDb = CompoundCatalogDBObject([db1, db2])
 
-        colnames = ['%s_id' % db1.objid,
-                    '%s_raJ2000' % db1.objid, '%s_decJ2000' % db1.objid,
-                    '%s_magMod' % db1.objid,
-                    '%s_raJ2000' % db2.objid, '%s_decJ2000' % db2.objid,
-                    '%s_magMod' % db2.objid]
+        prefix_colnames = ['%s_id' % db1.objid,
+                           '%s_raJ2000' % db1.objid, '%s_decJ2000' % db1.objid,
+                           '%s_magMod' % db1.objid,
+                           '%s_raJ2000' % db2.objid, '%s_decJ2000' % db2.objid,
+                           '%s_magMod' % db2.objid]
+
+        colnames = numpy.unique([compoundDb.name_map(name) for name in prefix_colnames])
 
         results = compoundDb.query_columns(colnames=colnames,
                                            obs_metadata=obs,
@@ -782,12 +784,24 @@ class CompoundWithObsMetaData(unittest.TestCase):
             for line in chunk:
                 ix = int(line['id'])
                 good_rows.append(ix)
-                self.assertAlmostEqual(line['%s_raJ2000' % db1.objid], self.controlArray['ra'][ix], 10)
-                self.assertAlmostEqual(line['%s_decJ2000' % db1.objid], self.controlArray['dec'][ix], 10)
-                self.assertAlmostEqual(line['%s_magMod' % db1.objid], self.controlArray['mag'][ix], 10)
-                self.assertAlmostEqual(line['%s_raJ2000' % db2.objid], 2.0*self.controlArray['ra'][ix], 10)
-                self.assertAlmostEqual(line['%s_decJ2000' % db2.objid], 2.0*self.controlArray['dec'][ix], 10)
-                self.assertAlmostEqual(line['%s_magMod' % db2.objid], 2.0*self.controlArray['mag'][ix], 10)
+                self.assertAlmostEqual(line[compoundDb.name_map('%s_raJ2000' % db1.objid)],
+                                       self.controlArray['ra'][ix], 10)
+
+                self.assertAlmostEqual(line[compoundDb.name_map('%s_decJ2000' % db1.objid)],
+                                       self.controlArray['dec'][ix], 10)
+
+                self.assertAlmostEqual(line[compoundDb.name_map('%s_magMod' % db1.objid)],
+                                       self.controlArray['mag'][ix], 10)
+
+                self.assertAlmostEqual(line[compoundDb.name_map('%s_raJ2000' % db2.objid)],
+                                       2.0*self.controlArray['ra'][ix], 10)
+
+                self.assertAlmostEqual(line[compoundDb.name_map('%s_decJ2000' % db2.objid)],
+                                       2.0*self.controlArray['dec'][ix], 10)
+
+                self.assertAlmostEqual(line[compoundDb.name_map('%s_magMod' % db2.objid)],
+                                       2.0*self.controlArray['mag'][ix], 10)
+
                 self.assertGreater(self.controlArray['ra'][ix], 100.0)
                 self.assertLess(self.controlArray['ra'][ix], 260.0)
                 self.assertGreater(self.controlArray['dec'][ix], -25.0)


### PR DESCRIPTION
This pull changes the CompoundInstanceCatalog/CompoundCatalogDBObject framework so that it is more efficient when querying the database.  If two InstanceCatalog classes use the exact same column from the database, it only gets queried once (it used to get queried once per InstanceCatalog).

There are also some small, unrelated changes that increase the efficiency of some aspects of InstanceCatalog generation.