### PR TITLE
Swap array.resize to np.resize(array)

### DIFF
--- a/tests/testInstanceCatalog.py
+++ b/tests/testInstanceCatalog.py
@@ -85,7 +85,7 @@ def createCannotBeNullTestDB(filename=None, add_nans=True, dir=None):
             output = np.array([(ii, values[0], values[1], values[2], w1, w2)], dtype=dtype)
         else:
             size = output.size
-            output.resize(size+1)
+            output = np.resize(output, size+1)
             output[size] = (ii, values[0], values[1], values[2], w1, w2)
 
         if np.isnan(values[0]) and add_nans:


### PR DESCRIPTION
In one of the python test scripts, there was a function 
```def createCannotBeNullTestDB(filename=None, add_nans=True, dir=None):``
which contained an 
`array.resize(newshape)`
which raised a ValueError with numpy 1.15.4 (and possibly how warnings/errors interact in py3.7?). 
Replacing this with
`np.resize(array, newshape)` 
works and fulfills the intended functionality (it copies 'array' into all values, instead of zeros in the added pieces of the array, but these additional pieces are rewritten in the next line anyway). 

Jenkins run 
https://ci.lsst.codes/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/29529/pipeline/ ... shows that sims_catUtils is failing, but it doesn't look related to this issue. (and sims_catalogs would have built first, so this seems like it's ok?). 