### PR TITLE
U/danielsf/tiles

### DIFF
--- a/python/lsst/sims/catalogs/db/dbConnection.py
+++ b/python/lsst/sims/catalogs/db/dbConnection.py
@@ -395,7 +395,7 @@ class DBObject(object):
         """
         return results
 
-    def _convert_results_to_numpy_recarray(self, results):
+    def _convert_results_to_numpy_recarray_dbobj(self, results):
         if self.dtype is None:
             """
             Determine the dtype from the data.
@@ -462,7 +462,7 @@ class DBObject(object):
     def _postprocess_arbitrary_results(self, results):
 
         if not isinstance(results, numpy.recarray):
-            retresults = self._convert_results_to_numpy_recarray(results)
+            retresults = self._convert_results_to_numpy_recarray_dbobj(results)
         else:
             retresults = results
 
@@ -792,7 +792,7 @@ class CatalogDBObject(with_metaclass(CatalogDBObjectMeta, DBObject)):
             query = query.filter(text(on_clause))
         return query
 
-    def _postprocess_results(self, results):
+    def _convert_results_to_numpy_recarray_catalogDBObj(self, results):
         """Post-process the query results to put them
         in a structured array.
 
@@ -844,6 +844,13 @@ class CatalogDBObject(with_metaclass(CatalogDBObjectMeta, DBObject)):
             results_array = [tuple(rr) for rr in results]
 
         retresults = numpy.rec.fromrecords(results_array, dtype=dtype)
+        return retresults
+
+    def _postprocess_results(self, results):
+        if not isinstance(results, numpy.recarray):
+            retresults = self._convert_results_to_numpy_recarray_catalogDBObj(results)
+        else:
+            retresults = results
         return self._final_pass(retresults)
 
     def query_columns(self, colnames=None, chunk_size=None,

--- a/python/lsst/sims/catalogs/db/dbConnection.py
+++ b/python/lsst/sims/catalogs/db/dbConnection.py
@@ -395,15 +395,7 @@ class DBObject(object):
         """
         return results
 
-    def _postprocess_results(self, results):
-        """
-        This wrapper exists so that a ChunkIterator built from a DBObject
-        can have the same API as a ChunkIterator built from a CatalogDBObject
-        """
-        return self._postprocess_arbitrary_results(results)
-
-    def _postprocess_arbitrary_results(self, results):
-
+    def _convert_results_to_numpy_recarray(self, results):
         if self.dtype is None:
             """
             Determine the dtype from the data.
@@ -457,6 +449,23 @@ class DBObject(object):
             return numpy.recarray((0,), dtype = self.dtype)
 
         retresults = numpy.rec.fromrecords([tuple(xx) for xx in results],dtype = self.dtype)
+        return retresults
+
+    def _postprocess_results(self, results):
+        """
+        This wrapper exists so that a ChunkIterator built from a DBObject
+        can have the same API as a ChunkIterator built from a CatalogDBObject
+        """
+        return self._postprocess_arbitrary_results(results)
+
+
+    def _postprocess_arbitrary_results(self, results):
+
+        if not isinstance(results, numpy.recarray):
+            retresults = self._convert_results_to_numpy_recarray(results)
+        else:
+            retresults = results
+
         return self._final_pass(retresults)
 
     def execute_arbitrary(self, query, dtype = None):


### PR DESCRIPTION
This is the pull request in support of moving the CatSim server from the Windows machine over to epyc. Here are the instructions for actually connecting remotely to the database on epyc (I will slack you the password and username).

The ssh command to establish the tunnel to the server is now:

ssh -N -L 51433:localhost:1433 lsst-sims@epyc.astro.washington.edu

The new CatalogDBObject classes you want to use are:

StarObj -> UWStarCatalogObj
GalaxyTileObj -> UWGalaxyTileObj
GalaxyDiskObj -> UWGalaxyDiskObj
GalaxyBulgeObj -> UWGalaxyBulgeObj
GalaxyAgnObj -> UWGalaxyAgnObj

all of which can be imported from lsst.sims.catUtils.baseCatalogModels