### PR TITLE
DM-27457: Move empty auth file to installed directory.

### DIFF
--- a/python/lsst/sims/catalogs/db/dbConnection.py
+++ b/python/lsst/sims/catalogs/db/dbConnection.py
@@ -162,7 +162,9 @@ class DBConnection(object):
                 # Use an empty file in this package, which causes
                 # a fallback to database-native authentication.
                 authdir = getPackageDir('sims_catalogs')
-            auth = DbAuth(os.path.join(authdir, ".lsst", "db-auth.yaml"))
+                auth = DbAuth(os.path.join(authdir, "tests", "db-auth.yaml"))
+            else:
+                auth = DbAuth(os.path.join(authdir, ".lsst", "db-auth.yaml"))
             username, password = auth.getAuth(
                     self._driver, host=self._host, port=self._port,
                     database=self._database)

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -2,4 +2,5 @@
 import os
 from lsst.sconsUtils import scripts, env
 
+Execute(Chmod("db-auth.yaml", 0o600))
 scripts.BasicSConscript.tests()


### PR DESCRIPTION
The `.lsst` directory isn't installed, so the auth file is not available.  Move it to the `tests` directory (which is where it is used) and ensure that it has the proper permissions.